### PR TITLE
[PB-776]:(feature) Drive API client + Network API client + Trash API client

### DIFF
--- a/Sources/InternxtSwiftCore/Extensions/Encodable.swift
+++ b/Sources/InternxtSwiftCore/Extensions/Encodable.swift
@@ -1,0 +1,20 @@
+//
+//  Encodable.swift
+//  
+//
+//  Created by Robert Garcia on 7/8/23.
+//
+
+import Foundation
+
+extension Encodable {
+    
+    func toJson() -> Data? {
+        do {
+            return try JSONEncoder().encode(self)
+        } catch {
+          
+            return nil
+        }
+    }
+}

--- a/Sources/InternxtSwiftCore/InternxtSwiftCore.swift
+++ b/Sources/InternxtSwiftCore/InternxtSwiftCore.swift
@@ -4,6 +4,6 @@
 public struct InternxtSwiftCore {
     
     public func initialize(config: Config) {
-        ConfigLoader().load(config: config)
+        CoreConfigLoader().load(config: config)
     }
 }

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
@@ -68,7 +68,7 @@ struct APIClient {
         }
    
         var urlRequest = URLRequest(url: url )
-        urlRequest.httpMethod = endpoint.method.rawValue
+        urlRequest.httpMethod = endpoint.method.rawValue.lowercased()
         
         print("METHOD")
         print(endpoint.method.rawValue)

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
@@ -46,7 +46,7 @@ struct APIClient {
                     }
                     
                     if(debugResponse == true) {
-                        print("\(endpoint.path) response is \(data?.description)")
+                        print("\(endpoint.path) response is \(String(decoding: data!, as: UTF8.self))")
                     }
                     let json = try JSONDecoder().decode(T.self, from: data!)
                     continuation.resume(with:.success(json))

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
@@ -37,9 +37,9 @@ struct APIClient {
                 
                 do {
                     
-                    if(data == nil) {
+                    if(data?.isEmpty == true) {
                         if(debugResponse == true) {
-                            print("\(endpoint.path) response is nil")
+                            print("\(endpoint.path) response is empty")
                         }
                         continuation.resume(with:.failure(APIError.invalidResponse))
                         return

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
@@ -77,7 +77,7 @@ struct APIClient {
             urlRequest.setValue("Bearer \(self.token)", forHTTPHeaderField:"Authorization")
         }
         if endpoint.body != nil {
-            urlRequest.httpBody = try JSONSerialization.data(withJSONObject: endpoint.body as Any, options: [])
+            urlRequest.httpBody = endpoint.body!
         }
             
         

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
@@ -37,6 +37,9 @@ struct APIClient {
                 
                 do {
                     
+                    let httpResponse = response as! HTTPURLResponse
+                    
+                    print("Response status code: \(httpResponse.statusCode)")
                     if(data?.isEmpty == true) {
                         if(debugResponse == true) {
                             print("\(endpoint.path) response is empty")

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
@@ -23,6 +23,9 @@ struct APIClient {
     func fetch<T: Decodable>(type: T.Type , _ endpoint: Endpoint) async throws -> T  {
        
         return try await withCheckedThrowingContinuation { continuation in
+            
+            
+            
             let request = self.buildURLRequest(endpoint: endpoint)
                     
             if(request == nil) {
@@ -49,16 +52,17 @@ struct APIClient {
                 }
             }
         }
-        
-        
-        
     }
     
     
     private func buildURLRequest(endpoint: Endpoint) -> URLRequest? {
         var urlRequest = URLRequest(url: URL(string: endpoint.path)!)
         urlRequest.httpMethod = endpoint.method.rawValue
-                
+        
+        
+        if(self.token.isEmpty == false) {
+            urlRequest.setValue("Bearer \(self.token)", forHTTPHeaderField:"Authorization")
+        }
         if let body = endpoint.parameters,
             !body.isEmpty,
             let postData = (try? JSONSerialization.data(withJSONObject: endpoint.body as Any, options: [])) {

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
@@ -36,7 +36,7 @@ struct APIClient {
                 }
                 
                 do {
-                    
+                    print("Response status code is \((response as! HTTPURLResponse).statusCode)")
                     if(data == nil) {
                         if(debugResponse == true) {
                             print("\(endpoint.path) response is nil")
@@ -70,13 +70,11 @@ struct APIClient {
         var urlRequest = URLRequest(url: url )
         urlRequest.httpMethod = endpoint.method.rawValue.lowercased()
         
-        print("METHOD")
-        print(endpoint.method.rawValue)
-        
         if(self.token.isEmpty == false) {
             urlRequest.setValue("Bearer \(self.token)", forHTTPHeaderField:"Authorization")
         }
         if endpoint.body != nil {
+            print("Endpoint body \(String(data: endpoint.body!, encoding: .utf8))")
             urlRequest.httpBody = endpoint.body!
         }
             

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
@@ -36,7 +36,7 @@ struct APIClient {
   
     func fetch<T: Decodable>(type: T.Type? , _ endpoint: Endpoint, debugResponse: Bool?) async throws -> T  {
         let request: URLRequest = try buildURLRequest(endpoint: endpoint)
-
+        
         return try await withCheckedThrowingContinuation { continuation in
             
             let task = URLSession(configuration: .default).dataTask(with: request) { (data, response, error) in
@@ -63,7 +63,6 @@ struct APIClient {
                     
                 }
             }
-            
             task.resume()
         }
     }

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
@@ -74,11 +74,11 @@ struct APIClient {
         if(self.token.isEmpty == false) {
             urlRequest.setValue("Bearer \(self.token)", forHTTPHeaderField:"Authorization")
         }
-        if let body = endpoint.parameters,
-            !body.isEmpty,
-            let postData = (try? JSONSerialization.data(withJSONObject: endpoint.body as Any, options: [])) {
-            urlRequest.httpBody = postData
+        if endpoint.body != nil {
+            urlRequest.httpBody = try JSONSerialization.data(withJSONObject: endpoint.body as Any, options: [])
         }
+            
+        
         
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
@@ -70,6 +70,8 @@ struct APIClient {
         var urlRequest = URLRequest(url: url )
         urlRequest.httpMethod = endpoint.method.rawValue
         
+        print("METHOD")
+        print(endpoint.method.rawValue)
         
         if(self.token.isEmpty == false) {
             urlRequest.setValue("Bearer \(self.token)", forHTTPHeaderField:"Authorization")

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
@@ -24,7 +24,7 @@ struct APIClient {
     }
     
   
-    func fetch<T: Decodable>(type: T.Type , _ endpoint: Endpoint) async throws -> T  {
+    func fetch<T: Decodable>(type: T.Type , _ endpoint: Endpoint, debugResponse: Bool?) async throws -> T  {
         let request: URLRequest = try buildURLRequest(endpoint: endpoint)
 
         return try await withCheckedThrowingContinuation { continuation in
@@ -36,9 +36,17 @@ struct APIClient {
                 }
                 
                 do {
+                    
                     if(data == nil) {
+                        if(debugResponse == true) {
+                            print("\(endpoint.path) response is nil")
+                        }
                         continuation.resume(with:.failure(APIError.invalidResponse))
                         return
+                    }
+                    
+                    if(debugResponse == true) {
+                        print("\(endpoint.path) response is \(data?.description)")
                     }
                     let json = try JSONDecoder().decode(T.self, from: data!)
                     continuation.resume(with:.success(json))

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
@@ -36,7 +36,7 @@ struct APIClient {
                 }
                 
                 do {
-                    print("Response status code is \((response as! HTTPURLResponse).statusCode)")
+                    
                     if(data == nil) {
                         if(debugResponse == true) {
                             print("\(endpoint.path) response is nil")

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
@@ -20,7 +20,7 @@ struct APIClient {
     }
     
   
-    func fetch<T: Decodable>(type: T.Type , _ endpoint: Endpoint) async throws -> T?  {
+    func fetch<T: Decodable>(type: T.Type , _ endpoint: Endpoint) async throws -> T  {
        
         return try await withCheckedThrowingContinuation { continuation in
             let request = self.buildURLRequest(endpoint: endpoint)
@@ -37,7 +37,7 @@ struct APIClient {
                 
                 do {
                     if(data == nil) {
-                        continuation.resume(with:.success(nil))
+                        continuation.resume(with:.failure(APIError.invalidResponse))
                         return
                     }
                     let json = try JSONDecoder().decode(T.self, from: data!)

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
@@ -48,6 +48,10 @@ struct APIClient {
 
                 do {
                     
+                    if data == nil {
+                        throw APIClientError(statusCode: httpResponse.statusCode, message: "Response is empty")
+                    }
+                    
                     if(debugResponse == true) {
                         print("\(endpoint.path) response is \(String(decoding: data!, as: UTF8.self))")
                     }

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/Endpoint.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/Endpoint.swift
@@ -7,13 +7,18 @@
 
 import Foundation
 
-enum HTTPMethod: String {
+public enum HTTPMethod: String {
     case POST = "POST"
     case GET = "GET"
 }
-protocol Endpoint {
-    var path: String { get }
-    var method: HTTPMethod { get }
-    var body: Data? { get }
+
+
+public struct Endpoint {
+    public var path: String
+    public var method: HTTPMethod
+    public var body: Data?
+    init(path: String, method: HTTPMethod = HTTPMethod.GET, body: Data? = nil) {
+        
+    }
 }
 

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/Endpoint.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/Endpoint.swift
@@ -14,6 +14,6 @@ enum HTTPMethod: String {
 protocol Endpoint {
     var path: String { get }
     var method: HTTPMethod { get }
-    var body: Codable? { get }
+    var body: Encodable? { get }
 }
 

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/Endpoint.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/Endpoint.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 enum HTTPMethod: String {
-    case POST
-    case GET
+    case POST = "POST"
+    case GET = "GET"
 }
 protocol Endpoint {
     var path: String { get }

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/Endpoint.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/Endpoint.swift
@@ -18,7 +18,9 @@ public struct Endpoint {
     public var method: HTTPMethod
     public var body: Data?
     init(path: String, method: HTTPMethod = HTTPMethod.GET, body: Data? = nil) {
-        
+        self.path = path
+        self.method = method
+        self.body = body
     }
 }
 

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/Endpoint.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/Endpoint.swift
@@ -17,9 +17,3 @@ protocol Endpoint {
     var body: Codable? { get }
 }
 
-
-extension Endpoint {
-    var path: String { "" }
-    var method: HTTPMethod { .GET }
-    var parameters: [String: AnyObject]? { nil }
-}

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/Endpoint.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/Endpoint.swift
@@ -14,6 +14,6 @@ enum HTTPMethod: String {
 protocol Endpoint {
     var path: String { get }
     var method: HTTPMethod { get }
-    var body: Encodable? { get }
+    var body: Data? { get }
 }
 

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -49,4 +49,20 @@ public struct DriveAPI {
         
         return try await apiClient.fetch(type: CreateFolderResponse.self, endpoint, debugResponse: debug)
     }
+    
+    struct UpdateFolderEndpoint: Endpoint {
+        var body: Data?
+        let method: HTTPMethod =  HTTPMethod.POST
+        let path: String
+        init(path: String, body: Data?) {
+            self.path = path
+            self.body = body
+        }
+    }
+    
+    public func updateFolder(folderId: String, folderName: String, debug: Bool?) async throws -> CreateFolderResponse {
+        let endpoint = UpdateFolderEndpoint(path: "\(self.baseUrl)/storage/folder/\(folderId)/meta", body: UpdateFolderPayload(itemName: folderName).toJson())
+        
+        return try await apiClient.fetch(type: CreateFolderResponse.self, endpoint, debugResponse: debug)
+    }
 }

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -60,11 +60,11 @@ public struct DriveAPI {
         }
     }
     
-    public func updateFolder(folderId: String, folderName: String, debug: Bool?) async throws -> CreateFolderResponse {
+    public func updateFolder(folderId: String, folderName: String, debug: Bool?) async throws -> UpdateFolderResponse {
         let endpoint = UpdateFolderEndpoint(path: "\(self.baseUrl)/storage/folder/\(folderId)/meta", body: UpdateFolderPayload(
             metadata: MetadataUpdatePayload(itemName: folderName)
         ).toJson())
         
-        return try await apiClient.fetch(type: CreateFolderResponse.self, endpoint, debugResponse: debug)
+        return try await apiClient.fetch(type: UpdateFolderResponse.self, endpoint, debugResponse: debug)
     }
 }

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -35,7 +35,7 @@ public struct DriveAPI {
     
     struct CreateFolderEndpoint: Endpoint {
         let body: Codable?
-        let method =  HTTPMethod.POST
+        let method: HTTPMethod =  HTTPMethod.POST
         let path: String
         init(path: String, body: CreateFolderPayload) {
             self.path = path

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -26,7 +26,7 @@ public struct DriveAPI {
         }
     }
     
-    public func getFolderContent(folderId: String, debug: Bool? = false) async throws -> FetchFolderContentResponse {
+    public func getFolderContent(folderId: String, debug: Bool?) async throws -> FetchFolderContentResponse {
         let endpoint = GetFolderContentEndpoint(path: "\(self.baseUrl)/storage/v2/folder/\(folderId)")
         
         return try await apiClient.fetch(type: FetchFolderContentResponse.self, endpoint, debugResponse: debug)

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -19,10 +19,19 @@ public struct DriveAPI {
     
   
     
-    public func getFolderContent(folderId: String, debug: Bool = false) async throws -> FetchFolderContentResponse {
-        let endpoint = GetFolderContentEndpoint(path: "\(self.baseUrl)/storage/v2/folder/\(folderId)")
+    public func getFolderFiles(folderId: String, offset: Int = 0, limit: Int = 50, sort: String = "ASC", debug: Bool = false) async throws -> GetFolderFilesResponse {
         
-        return try await apiClient.fetch(type: FetchFolderContentResponse.self, endpoint, debugResponse: debug)
+        let query: String = "?offset=\(String(offset))&limit=\(String(limit))&sort=\(sort)"
+        let endpoint = GetFolderFilesEndpoint(path: "\(self.baseUrl)/folders/\(folderId)/files\(query)")
+        
+        return try await apiClient.fetch(type: GetFolderFilesResponse.self, endpoint, debugResponse: debug)
+    }
+    
+    public func getFolderFolders(folderId: String, offset: Int = 0, limit: Int = 50, sort: String = "ASC", debug: Bool = false) async throws -> GetFolderFoldersResponse {
+        let query: String = "?offset=\(String(offset))&limit=\(String(limit))&sort=\(sort)"
+        let endpoint = GetFolderFoldersEndpoint(path: "\(self.baseUrl)/folders/\(folderId)/folders\(query)")
+        
+        return try await apiClient.fetch(type: GetFolderFoldersResponse.self, endpoint, debugResponse: debug)
     }
     
     

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -9,9 +9,12 @@ import Foundation
 
 @available(macOS 10.15, *)
 struct DriveAPI {
-    private let apiClient = APIClient()
+    private let apiClient: APIClient
     private let configLoader = ConfigLoader()
     
+    init(authToken: String) {
+        self.apiClient = APIClient(urlSession: URLSession.shared, token: authToken)
+    }
     struct GetFolderContentEndpoint: Endpoint {
         let body: Codable? = nil
         let method =  HTTPMethod.GET

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -12,7 +12,7 @@ public struct DriveAPI {
     private let apiClient: APIClient
     private let configLoader = ConfigLoader()
     
-    init(authToken: String) {
+    public init(authToken: String) {
         self.apiClient = APIClient(urlSession: URLSession.shared, token: authToken)
     }
     struct GetFolderContentEndpoint: Endpoint {
@@ -20,7 +20,7 @@ public struct DriveAPI {
         let method =  HTTPMethod.GET
     }
     
-    func getFolderContent(folderId: String) async throws -> FetchFolderContentResponse {
+    public func getFolderContent(folderId: String) async throws -> FetchFolderContentResponse {
         let base = try configLoader.getConfigProperty(configKey: "DRIVE_URL")
         
         let path =   "\(base)/storage/v2/folder/\(folderId)"

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -18,7 +18,7 @@ public struct DriveAPI {
     }
     
     struct GetFolderContentEndpoint: Endpoint {
-        var body: Encodable? = nil
+        var body: Data? = nil
         let method =  HTTPMethod.GET
         let path: String
         init(path: String) {
@@ -34,10 +34,10 @@ public struct DriveAPI {
     
     
     struct CreateFolderEndpoint: Endpoint {
-        let body: Encodable?
+        var body: Data?
         let method: HTTPMethod =  HTTPMethod.POST
         let path: String
-        init(path: String, body: CreateFolderPayload) {
+        init(path: String, body: Data?) {
             self.path = path
             self.body = body
         }
@@ -45,7 +45,7 @@ public struct DriveAPI {
     
     
     public func createFolder(parentFolderId: Int, folderName: String, debug: Bool?) async throws -> CreateFolderResponse {
-        let endpoint = CreateFolderEndpoint(path: "\(self.baseUrl)/storage/v2/folder", body: CreateFolderPayload(parentFolderId: parentFolderId, folderName: folderName))
+        let endpoint = CreateFolderEndpoint(path: "\(self.baseUrl)/storage/v2/folder", body: CreateFolderPayload(parentFolderId: parentFolderId, folderName: folderName).toJson())
         
         return try await apiClient.fetch(type: CreateFolderResponse.self, endpoint, debugResponse: debug)
     }

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -61,7 +61,9 @@ public struct DriveAPI {
     }
     
     public func updateFolder(folderId: String, folderName: String, debug: Bool?) async throws -> CreateFolderResponse {
-        let endpoint = UpdateFolderEndpoint(path: "\(self.baseUrl)/storage/folder/\(folderId)/meta", body: UpdateFolderPayload(itemName: folderName).toJson())
+        let endpoint = UpdateFolderEndpoint(path: "\(self.baseUrl)/storage/folder/\(folderId)/meta", body: UpdateFolderPayload(
+            metadata: MetadataUpdatePayload(itemName: folderName)
+        ).toJson())
         
         return try await apiClient.fetch(type: CreateFolderResponse.self, endpoint, debugResponse: debug)
     }

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -31,4 +31,22 @@ public struct DriveAPI {
         
         return try await apiClient.fetch(type: FetchFolderContentResponse.self, endpoint, debugResponse: debug)
     }
+    
+    
+    struct CreateFolderEndpoint: Endpoint {
+        let body: Codable?
+        let method =  HTTPMethod.POST
+        let path: String
+        init(path: String, body: CreateFolderPayload) {
+            self.path = path
+            self.body = body
+        }
+    }
+    
+    
+    public func createFolder(parentFolderId: String, folderName: String, debug: Bool?) async throws -> CreateFolderResponse {
+        let endpoint = GetFolderContentEndpoint(path: "\(self.baseUrl)/storage/v2/folder")
+        
+        return try await apiClient.fetch(type: CreateFolderResponse.self, endpoint, debugResponse: debug)
+    }
 }

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -10,7 +10,7 @@ import Foundation
 @available(macOS 10.15, *)
 public struct DriveAPI {
     private let apiClient: APIClient
-    private let configLoader = ConfigLoader()
+    private let configLoader = CoreConfigLoader()
     
     public init(authToken: String) {
         self.apiClient = APIClient(urlSession: URLSession.shared, token: authToken)

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -19,7 +19,7 @@ public struct DriveAPI {
     
   
     
-    public func getFolderContent(folderId: String, debug: Bool?) async throws -> FetchFolderContentResponse {
+    public func getFolderContent(folderId: String, debug: Bool = false) async throws -> FetchFolderContentResponse {
         let endpoint = GetFolderContentEndpoint(path: "\(self.baseUrl)/storage/v2/folder/\(folderId)")
         
         return try await apiClient.fetch(type: FetchFolderContentResponse.self, endpoint, debugResponse: debug)
@@ -27,7 +27,7 @@ public struct DriveAPI {
     
     
     /// Creates a folder inside the parentFolderId given with the given name
-    public func createFolder(parentFolderId: Int, folderName: String, debug: Bool?) async throws -> CreateFolderResponse {
+    public func createFolder(parentFolderId: Int, folderName: String, debug: Bool = false) async throws -> CreateFolderResponse {
         let endpoint = CreateFolderEndpoint(path: "\(self.baseUrl)/storage/folder", body: CreateFolderPayload(parentFolderId: parentFolderId, folderName: folderName).toJson())
         
         return try await apiClient.fetch(type: CreateFolderResponse.self, endpoint, debugResponse: debug)
@@ -37,7 +37,7 @@ public struct DriveAPI {
     /// Given a folderId, updates the folder name, if the folder name conflicts with
     /// the remove folder name, an ApiClientError with 409 statusCode is throw
     
-    public func updateFolder(folderId: String, folderName: String, debug: Bool?) async throws -> UpdateFolderResponse {
+    public func updateFolder(folderId: String, folderName: String, debug: Bool = false) async throws -> UpdateFolderResponse {
         let endpoint = UpdateFolderEndpoint(path: "\(self.baseUrl)/storage/folder/\(folderId)/meta", body: UpdateFolderPayload(
             metadata: MetadataUpdatePayload(itemName: folderName)
         ).toJson())

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -18,7 +18,7 @@ public struct DriveAPI {
     }
     
     struct GetFolderContentEndpoint: Endpoint {
-        let body: Codable? = nil
+        var body: Encodable? = nil
         let method =  HTTPMethod.GET
         let path: String
         init(path: String) {
@@ -34,7 +34,7 @@ public struct DriveAPI {
     
     
     struct CreateFolderEndpoint: Endpoint {
-        let body: Codable?
+        let body: Encodable?
         let method: HTTPMethod =  HTTPMethod.POST
         let path: String
         init(path: String, body: CreateFolderPayload) {
@@ -44,8 +44,8 @@ public struct DriveAPI {
     }
     
     
-    public func createFolder(parentFolderId: String, folderName: String, debug: Bool?) async throws -> CreateFolderResponse {
-        let endpoint = GetFolderContentEndpoint(path: "\(self.baseUrl)/storage/v2/folder")
+    public func createFolder(parentFolderId: Int, folderName: String, debug: Bool?) async throws -> CreateFolderResponse {
+        let endpoint = CreateFolderEndpoint(path: "\(self.baseUrl)/storage/v2/folder", body: CreateFolderPayload(parentFolderId: parentFolderId, folderName: folderName))
         
         return try await apiClient.fetch(type: CreateFolderResponse.self, endpoint, debugResponse: debug)
     }

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -20,12 +20,14 @@ public struct DriveAPI {
     struct GetFolderContentEndpoint: Endpoint {
         let body: Codable? = nil
         let method =  HTTPMethod.GET
+        let path: String
+        init(path: String) {
+            self.path = path
+        }
     }
     
     public func getFolderContent(folderId: String) async throws -> FetchFolderContentResponse {
-        
-        let path =   "\(self.baseUrl)/storage/v2/folder/\(folderId)"
-        let endpoint = GetFolderContentEndpoint()
+        let endpoint = GetFolderContentEndpoint(path: "\(self.baseUrl)/storage/v2/folder/\(folderId)")
         
         return try await apiClient.fetch(type: FetchFolderContentResponse.self, endpoint)
     }

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -9,21 +9,22 @@ import Foundation
 
 @available(macOS 10.15, *)
 public struct DriveAPI {
+    private let baseUrl: String
     private let apiClient: APIClient
-    private let configLoader = CoreConfigLoader()
     
-    public init(authToken: String) {
+    public init(baseUrl: String, authToken: String) {
+        self.baseUrl = baseUrl
         self.apiClient = APIClient(urlSession: URLSession.shared, token: authToken)
     }
+    
     struct GetFolderContentEndpoint: Endpoint {
         let body: Codable? = nil
         let method =  HTTPMethod.GET
     }
     
     public func getFolderContent(folderId: String) async throws -> FetchFolderContentResponse {
-        let base = try configLoader.getConfigProperty(configKey: "DRIVE_URL")
         
-        let path =   "\(base)/storage/v2/folder/\(folderId)"
+        let path =   "\(self.baseUrl)/storage/v2/folder/\(folderId)"
         let endpoint = GetFolderContentEndpoint()
         
         return try await apiClient.fetch(type: FetchFolderContentResponse.self, endpoint)

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -19,17 +19,19 @@ public struct DriveAPI {
     
   
     
+    /// Get paginated files inside the given folder
     public func getFolderFiles(folderId: String, offset: Int = 0, limit: Int = 50, sort: String = "ASC", debug: Bool = false) async throws -> GetFolderFilesResponse {
         
         let query: String = "?offset=\(String(offset))&limit=\(String(limit))&sort=\(sort)"
-        let endpoint = GetFolderFilesEndpoint(path: "\(self.baseUrl)/folders/\(folderId)/files\(query)")
+        let endpoint = Endpoint(path: "\(self.baseUrl)/folders/\(folderId)/files\(query)")
         
         return try await apiClient.fetch(type: GetFolderFilesResponse.self, endpoint, debugResponse: debug)
     }
     
+    /// Get paginated folders inside the given folder
     public func getFolderFolders(folderId: String, offset: Int = 0, limit: Int = 50, sort: String = "ASC", debug: Bool = false) async throws -> GetFolderFoldersResponse {
         let query: String = "?offset=\(String(offset))&limit=\(String(limit))&sort=\(sort)"
-        let endpoint = GetFolderFoldersEndpoint(path: "\(self.baseUrl)/folders/\(folderId)/folders\(query)")
+        let endpoint = Endpoint(path: "\(self.baseUrl)/folders/\(folderId)/folders\(query)")
         
         return try await apiClient.fetch(type: GetFolderFoldersResponse.self, endpoint, debugResponse: debug)
     }
@@ -37,7 +39,10 @@ public struct DriveAPI {
     
     /// Creates a folder inside the parentFolderId given with the given name
     public func createFolder(parentFolderId: Int, folderName: String, debug: Bool = false) async throws -> CreateFolderResponse {
-        let endpoint = CreateFolderEndpoint(path: "\(self.baseUrl)/storage/folder", body: CreateFolderPayload(parentFolderId: parentFolderId, folderName: folderName).toJson())
+        let endpoint = Endpoint(
+            path: "\(self.baseUrl)/storage/folder",
+            body: CreateFolderPayload(parentFolderId: parentFolderId, folderName: folderName).toJson()
+        )
         
         return try await apiClient.fetch(type: CreateFolderResponse.self, endpoint, debugResponse: debug)
     }
@@ -47,14 +52,30 @@ public struct DriveAPI {
     /// the remove folder name, an ApiClientError with 409 statusCode is throw
     
     public func updateFolder(folderId: String, folderName: String, debug: Bool = false) async throws -> UpdateFolderResponse {
-        let endpoint = UpdateFolderEndpoint(path: "\(self.baseUrl)/storage/folder/\(folderId)/meta", body: UpdateFolderPayload(
-            metadata: MetadataUpdatePayload(itemName: folderName)
-        ).toJson())
+        let endpoint = Endpoint(
+            path: "\(self.baseUrl)/storage/folder/\(folderId)/meta",
+            body: UpdateFolderPayload(
+                    metadata: MetadataUpdatePayload(itemName: folderName)
+                    ).toJson()
+        )
         
         return try await apiClient.fetch(type: UpdateFolderResponse.self, endpoint, debugResponse: debug)
     }
-    
-    public func trashItems() {
+    public func getFolderMetaById(id: String, debug: Bool = false) async throws -> GetFolderMetaByIdResponse {
+        let endpoint = Endpoint(
+            path: "\(self.baseUrl)/storage/folders/\(id)/metadata",
+            method: .GET
+        )
         
+        return try await apiClient.fetch(type: GetFolderMetaByIdResponse.self, endpoint, debugResponse: debug)
+    }
+    
+    public func getFileMetaById(id: String, debug: Bool = false)  async throws -> GetFileMetaByIdResponse {
+        let endpoint = Endpoint(
+            path: "\(self.baseUrl)/storage/files/\(id)/metadata",
+            method: .GET
+        )
+        
+        return try await apiClient.fetch(type: GetFileMetaByIdResponse.self, endpoint, debugResponse: debug)
     }
 }

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -17,14 +17,7 @@ public struct DriveAPI {
         self.apiClient = APIClient(urlSession: URLSession.shared, token: authToken)
     }
     
-    struct GetFolderContentEndpoint: Endpoint {
-        var body: Data? = nil
-        let method =  HTTPMethod.GET
-        let path: String
-        init(path: String) {
-            self.path = path
-        }
-    }
+  
     
     public func getFolderContent(folderId: String, debug: Bool?) async throws -> FetchFolderContentResponse {
         let endpoint = GetFolderContentEndpoint(path: "\(self.baseUrl)/storage/v2/folder/\(folderId)")
@@ -33,32 +26,16 @@ public struct DriveAPI {
     }
     
     
-    struct CreateFolderEndpoint: Endpoint {
-        var body: Data?
-        let method: HTTPMethod =  HTTPMethod.POST
-        let path: String
-        init(path: String, body: Data?) {
-            self.path = path
-            self.body = body
-        }
-    }
-    
-    
+    /// Creates a folder inside the parentFolderId given with the given name
     public func createFolder(parentFolderId: Int, folderName: String, debug: Bool?) async throws -> CreateFolderResponse {
         let endpoint = CreateFolderEndpoint(path: "\(self.baseUrl)/storage/folder", body: CreateFolderPayload(parentFolderId: parentFolderId, folderName: folderName).toJson())
         
         return try await apiClient.fetch(type: CreateFolderResponse.self, endpoint, debugResponse: debug)
     }
     
-    struct UpdateFolderEndpoint: Endpoint {
-        var body: Data?
-        let method: HTTPMethod =  HTTPMethod.POST
-        let path: String
-        init(path: String, body: Data?) {
-            self.path = path
-            self.body = body
-        }
-    }
+    
+    /// Given a folderId, updates the folder name, if the folder name conflicts with
+    /// the remove folder name, an ApiClientError with 409 statusCode is throw
     
     public func updateFolder(folderId: String, folderName: String, debug: Bool?) async throws -> UpdateFolderResponse {
         let endpoint = UpdateFolderEndpoint(path: "\(self.baseUrl)/storage/folder/\(folderId)/meta", body: UpdateFolderPayload(
@@ -66,5 +43,9 @@ public struct DriveAPI {
         ).toJson())
         
         return try await apiClient.fetch(type: UpdateFolderResponse.self, endpoint, debugResponse: debug)
+    }
+    
+    public func trashItems() {
+        
     }
 }

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -26,9 +26,9 @@ public struct DriveAPI {
         }
     }
     
-    public func getFolderContent(folderId: String) async throws -> FetchFolderContentResponse {
+    public func getFolderContent(folderId: String, debug: Bool? = false) async throws -> FetchFolderContentResponse {
         let endpoint = GetFolderContentEndpoint(path: "\(self.baseUrl)/storage/v2/folder/\(folderId)")
         
-        return try await apiClient.fetch(type: FetchFolderContentResponse.self, endpoint)
+        return try await apiClient.fetch(type: FetchFolderContentResponse.self, endpoint, debugResponse: debug)
     }
 }

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @available(macOS 10.15, *)
-struct DriveAPI {
+public struct DriveAPI {
     private let apiClient: APIClient
     private let configLoader = ConfigLoader()
     

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -7,3 +7,22 @@
 
 import Foundation
 
+@available(macOS 10.15, *)
+struct DriveAPI {
+    private let apiClient = APIClient()
+    private let configLoader = ConfigLoader()
+    
+    struct GetFolderContentEndpoint: Endpoint {
+        let body: Codable? = nil
+        let method =  HTTPMethod.GET
+    }
+    
+    func getFolderContent(folderId: String) async throws -> FetchFolderContentResponse {
+        let base = try configLoader.getConfigProperty(configKey: "DRIVE_URL")
+        
+        let path =   "\(base)/storage/v2/folder/\(folderId)"
+        let endpoint = GetFolderContentEndpoint()
+        
+        return try await apiClient.fetch(type: FetchFolderContentResponse.self, endpoint)
+    }
+}

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -45,7 +45,7 @@ public struct DriveAPI {
     
     
     public func createFolder(parentFolderId: Int, folderName: String, debug: Bool?) async throws -> CreateFolderResponse {
-        let endpoint = CreateFolderEndpoint(path: "\(self.baseUrl)/storage/v2/folder", body: CreateFolderPayload(parentFolderId: parentFolderId, folderName: folderName).toJson())
+        let endpoint = CreateFolderEndpoint(path: "\(self.baseUrl)/storage/folder", body: CreateFolderPayload(parentFolderId: parentFolderId, folderName: folderName).toJson())
         
         return try await apiClient.fetch(type: CreateFolderResponse.self, endpoint, debugResponse: debug)
     }

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -17,8 +17,6 @@ public struct DriveAPI {
         self.apiClient = APIClient(urlSession: URLSession.shared, token: authToken)
     }
     
-  
-    
     /// Get paginated files inside the given folder
     public func getFolderFiles(folderId: String, offset: Int = 0, limit: Int = 50, sort: String = "ASC", debug: Bool = false) async throws -> GetFolderFilesResponse {
         
@@ -37,7 +35,7 @@ public struct DriveAPI {
     }
     
     
-    /// Creates a folder inside the parentFolderId given with the given name
+    /// Creates a folder inside the given parentFolderId with the given name
     public func createFolder(parentFolderId: Int, folderName: String, debug: Bool = false) async throws -> CreateFolderResponse {
         let endpoint = Endpoint(
             path: "\(self.baseUrl)/storage/folder",
@@ -61,6 +59,8 @@ public struct DriveAPI {
         
         return try await apiClient.fetch(type: UpdateFolderResponse.self, endpoint, debugResponse: debug)
     }
+    
+    /// Retrieves the folder metadata by the folder id
     public func getFolderMetaById(id: String, debug: Bool = false) async throws -> GetFolderMetaByIdResponse {
         let endpoint = Endpoint(
             path: "\(self.baseUrl)/storage/folders/\(id)/metadata",
@@ -70,6 +70,7 @@ public struct DriveAPI {
         return try await apiClient.fetch(type: GetFolderMetaByIdResponse.self, endpoint, debugResponse: debug)
     }
     
+    /// Retrieves the filer metadata by the file id
     public func getFileMetaById(id: String, debug: Bool = false)  async throws -> GetFileMetaByIdResponse {
         let endpoint = Endpoint(
             path: "\(self.baseUrl)/storage/files/\(id)/metadata",

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/NetworkAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/NetworkAPI.swift
@@ -9,7 +9,7 @@ import Foundation
 
 
 @available(macOS 10.15, *)
-struct NetworkAPI {
+public struct NetworkAPI {
     private let apiClient = APIClient()
     private let configLoader = ConfigLoader()
     

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/NetworkAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/NetworkAPI.swift
@@ -18,15 +18,35 @@ public struct NetworkAPI {
         self.apiClient = APIClient(urlSession: URLSession.shared, token: authToken)
     }
     
-    func startUpload(bucketId: String,  uploadSize: Int,parts: Int = 1, debug: Bool = false) async throws -> UploadResult? {
-        let path =   "\(self.baseUrl)/v2/buckets/\(bucketId)/files/start?multiparts=\(String(parts))"
-        let endpoint = StartUploadEndpoint(body: StartUploadPayload(
-            uploads: [NetworkUploadPayload(
-                index: 0,
-                size: uploadSize
-            )]
-        ).toJson())
+    public func startUpload(bucketId: String,  uploadSize: Int,parts: Int = 1, debug: Bool = false) async throws -> StartUploadResponse {
+        let endpoint = Endpoint(
+            path: "\(self.baseUrl)/v2/buckets/\(bucketId)/files/start?multiparts=\(String(parts))",
+            method: .POST,
+            body: StartUploadPayload(
+                uploads: [NetworkUploadPayload(
+                    index: 0,
+                    size: uploadSize
+                )]
+            ).toJson()
+        )
         
-        return try await apiClient.fetch(type: UploadResult.self, endpoint, debugResponse: debug)
+        return try await apiClient.fetch(type: StartUploadResponse.self, endpoint, debugResponse: debug)
+    }
+    
+    public func finishUpload(bucketId: String, payload: FinishUploadPayload, debug: Bool = false) async throws -> FinishUploadResponse {
+        let endpoint = Endpoint(
+            path: "\(self.baseUrl)/v2/buckets/\(bucketId)/files/finish",
+            method: .POST,
+            body: payload.toJson()
+        )
+        return try await apiClient.fetch(type: FinishUploadResponse.self, endpoint, debugResponse: debug)
+    }
+    
+    
+    public func getFileInfo(bucketId: String, fileId: String) {
+        let endpoint = Endpoint(
+            path: "\(self.baseUrl)/v2/buckets/\(bucketId)/files/\(fileId)/info"
+        )
+    
     }
 }

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/NetworkAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/NetworkAPI.swift
@@ -25,7 +25,7 @@ public struct NetworkAPI {
                 index: 0,
                 size: uploadSize
             )]
-        ))
+        ).toJson())
         
         return try await apiClient.fetch(type: UploadResult.self, endpoint, debugResponse: debug)
     }

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/NetworkAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/NetworkAPI.swift
@@ -11,7 +11,7 @@ import Foundation
 @available(macOS 10.15, *)
 public struct NetworkAPI {
     private let apiClient = APIClient()
-    private let configLoader = ConfigLoader()
+    private let configLoader = CoreConfigLoader()
     
     func startUpload(bucketId: String,  uploadSize: Int,parts: Int = 1) async throws -> UploadResult? {
         let base = try configLoader.getConfigProperty(configKey: "NETWORK_URL")

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/NetworkAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/NetworkAPI.swift
@@ -18,7 +18,7 @@ public struct NetworkAPI {
         self.apiClient = APIClient(urlSession: URLSession.shared, token: authToken)
     }
     
-    func startUpload(bucketId: String,  uploadSize: Int,parts: Int = 1) async throws -> UploadResult? {
+    func startUpload(bucketId: String,  uploadSize: Int,parts: Int = 1, debug: Bool? = nil) async throws -> UploadResult? {
         let path =   "\(self.baseUrl)/v2/buckets/\(bucketId)/files/start?multiparts=\(String(parts))"
         let endpoint = StartUploadEndpoint(body: StartUploadPayload(
             uploads: [NetworkUploadPayload(
@@ -27,6 +27,6 @@ public struct NetworkAPI {
             )]
         ))
         
-        return try await apiClient.fetch(type: UploadResult.self, endpoint)
+        return try await apiClient.fetch(type: UploadResult.self, endpoint, debugResponse: debug)
     }
 }

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/NetworkAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/NetworkAPI.swift
@@ -10,12 +10,16 @@ import Foundation
 
 @available(macOS 10.15, *)
 public struct NetworkAPI {
-    private let apiClient = APIClient()
-    private let configLoader = CoreConfigLoader()
+    private let baseUrl: String
+    private let apiClient: APIClient
+
+    public init(baseUrl: String, authToken: String) {
+        self.baseUrl = baseUrl
+        self.apiClient = APIClient(urlSession: URLSession.shared, token: authToken)
+    }
     
     func startUpload(bucketId: String,  uploadSize: Int,parts: Int = 1) async throws -> UploadResult? {
-        let base = try configLoader.getConfigProperty(configKey: "NETWORK_URL")
-        let path =   "\(base)/v2/buckets/\(bucketId)/files/start?multiparts=\(String(parts))"
+        let path =   "\(self.baseUrl)/v2/buckets/\(bucketId)/files/start?multiparts=\(String(parts))"
         let endpoint = StartUploadEndpoint(body: StartUploadPayload(
             uploads: [NetworkUploadPayload(
                 index: 0,

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/NetworkAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/NetworkAPI.swift
@@ -18,7 +18,7 @@ public struct NetworkAPI {
         self.apiClient = APIClient(urlSession: URLSession.shared, token: authToken)
     }
     
-    func startUpload(bucketId: String,  uploadSize: Int,parts: Int = 1, debug: Bool? = nil) async throws -> UploadResult? {
+    func startUpload(bucketId: String,  uploadSize: Int,parts: Int = 1, debug: Bool = false) async throws -> UploadResult? {
         let path =   "\(self.baseUrl)/v2/buckets/\(bucketId)/files/start?multiparts=\(String(parts))"
         let endpoint = StartUploadEndpoint(body: StartUploadPayload(
             uploads: [NetworkUploadPayload(

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/TrashAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/TrashAPI.swift
@@ -1,0 +1,24 @@
+//
+//  TrashAPI.swift
+//  
+//
+//  Created by Robert Garcia on 7/8/23.
+//
+
+import Foundation
+
+@available(macOS 10.15, *)
+public struct TrashAPI {
+    private let baseUrl: String
+    private let apiClient: APIClient
+    
+    public init(baseUrl: String, authToken: String) {
+        self.baseUrl = baseUrl
+        self.apiClient = APIClient(urlSession: URLSession.shared, token: authToken)
+    }
+    
+    public func trashItems(itemsToTrash: AddItemsToTrashPayload) async throws -> Void {
+        let endpoint = AddItemsToTrashEndpoint(path: "\(self.baseUrl)/storage/trash/add", body: itemsToTrash.toJson())
+        
+    }
+}

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/TrashAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/TrashAPI.swift
@@ -17,8 +17,20 @@ public struct TrashAPI {
         self.apiClient = APIClient(urlSession: URLSession.shared, token: authToken)
     }
     
-    public func trashItems(itemsToTrash: AddItemsToTrashPayload) async throws -> Void {
+    public func trashItems(itemsToTrash: AddItemsToTrashPayload, debug: Bool = false) async throws -> Bool {
         let endpoint = AddItemsToTrashEndpoint(path: "\(self.baseUrl)/storage/trash/add", body: itemsToTrash.toJson())
         
+        do {
+            try await apiClient.fetch(type: AddItemsToTrashResponse.self, endpoint, debugResponse: debug)
+            
+            return true
+        } catch {
+            guard let apiClientError = error as? APIClientError else {
+                throw error
+            }
+            // Trash endpoint doesn't return a body, instead we know if the request was successful by the statusCode,
+            // the APIClient will throw an empty body error in this case with a 200 status code
+            return apiClientError.statusCode == 200
+        }
     }
 }

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/TrashAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/TrashAPI.swift
@@ -18,7 +18,7 @@ public struct TrashAPI {
     }
     
     public func trashItems(itemsToTrash: AddItemsToTrashPayload, debug: Bool = false) async throws -> Bool {
-        let endpoint = AddItemsToTrashEndpoint(path: "\(self.baseUrl)/storage/trash/add", body: itemsToTrash.toJson())
+        let endpoint = Endpoint(path: "\(self.baseUrl)/storage/trash/add", body: itemsToTrash.toJson())
         
         do {
             try await apiClient.fetch(type: AddItemsToTrashResponse.self, endpoint, debugResponse: debug)

--- a/Sources/InternxtSwiftCore/Services/Network/Encrypt.swift
+++ b/Sources/InternxtSwiftCore/Services/Network/Encrypt.swift
@@ -13,7 +13,7 @@ struct EncryptConfig {
 }
 
 @available(macOS 10.15, *)
-struct Encrypt {
+public struct Encrypt {
     private let AES = AESCipher()
     private let cryptoUtils = CryptoUtils()
     

--- a/Sources/InternxtSwiftCore/Services/Network/NetworkFacade.swift
+++ b/Sources/InternxtSwiftCore/Services/Network/NetworkFacade.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct NetworkFacade {
+public struct NetworkFacade {
     private let apiUrl: String
     private let bridgeUser: String
     init(apiUrl: String , bridgeUser: String, userId: String) {

--- a/Sources/InternxtSwiftCore/Services/Network/Upload.swift
+++ b/Sources/InternxtSwiftCore/Services/Network/Upload.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @available(macOS 10.15, *)
-struct Upload {
+public struct Upload {
     private let encrypt = Encrypt()
     private let cryptoUtils = CryptoUtils()
     private let networkApi = NetworkAPI()

--- a/Sources/InternxtSwiftCore/Services/Network/Upload.swift
+++ b/Sources/InternxtSwiftCore/Services/Network/Upload.swift
@@ -11,7 +11,8 @@ import Foundation
 public struct Upload {
     private let encrypt = Encrypt()
     private let cryptoUtils = CryptoUtils()
-    private let networkApi = NetworkAPI()
+    
+   
     func start( bucketId: String, mnemonic: String, filepath: String) throws -> Void {
         let inputStream = InputStream(url: URL(fileURLWithPath: filepath))
         
@@ -31,5 +32,7 @@ public struct Upload {
         let iv = cryptoUtils.hexStringToBytes(String(hexIv))
         
         let fileKey = try encrypt.generateFileKey(mnemonic: mnemonic, bucketId: bucketId, index: index!)
+        
+        // File is encrypted at outputFilePath, make sure by reverse verifying the content hash
     }
 }

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -79,6 +79,11 @@ public struct CreateFolderResponse: Decodable {
     public let userId: Int
 }
 
+public struct UpdateFolderResponse: Decodable {
+    public let id: Int
+    public let name: String
+}
+
 public struct MetadataUpdatePayload: Encodable {
     public let itemName: String
 }

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -58,3 +58,19 @@ public struct FetchFolderContentResponse: Decodable {
     public let userId: Int
     public let user_id: Int
 }
+
+public struct CreateFolderPayload: Codable {
+    public let parentFolderId: Int
+    public let folderName: String
+}
+public struct CreateFolderResponse: Decodable {
+    public let bucket: String
+    public let id: Int
+    public let name: String
+    public let plain_name: String?
+    public let parentId: Int?
+    // ISO Date
+    public let createdAt: String
+    public let updatedAt: String
+    public let userId: Int
+}

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -44,7 +44,7 @@ public struct GetFolderFilesResult: Decodable {
 }
 
 public struct GetFolderFilesResponse: Decodable {
-    public let result: GetFolderFilesResult
+    public let result: Array<GetFolderFilesResult>
 }
 
 struct GetFolderFoldersEndpoint: Endpoint {
@@ -77,7 +77,7 @@ public struct GetFolderFoldersResult: Decodable {
 }
 
 public struct GetFolderFoldersResponse: Decodable {
-    public let result: GetFolderFoldersResult
+    public let result: Array<GetFolderFoldersResult>
 }
 
 

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 
-struct GetFolderContentEndpoint: Endpoint {
+struct GetFolderFilesEndpoint: Endpoint {
     var body: Data? = nil
     let method =  HTTPMethod.GET
     let path: String
@@ -17,56 +17,69 @@ struct GetFolderContentEndpoint: Endpoint {
     }
 }
 
-public struct FolderChild: Decodable {
-    // ISO string
-    public let createdAt: String
-    public let encrypt_version: String?
+public struct GetFolderFilesResult: Decodable {
     public let id: Int
-    public let name: String
-    public let plain_name: String?
-    public let parentId: Int
-    public let parent_id: Int
-    public let updatedAt: String
-    public let userId: Int
-    public let user_id: Int
-}
-
-public struct DriveFileData: Decodable {
-    public let bucket: String
-    // ISO string
-    public let createdAt: String
-    public let created_at: String
-    public let deleted: Bool
-    public let encrypt_version: String?
     public let fileId: String
+    public let name: String
+    public let type: String?
+    // Size string in bytes
+    public let size: String
+    public let bucket: String
     public let folderId: Int
-    public let folder_id: Int
-    public let id: Int
-    public let name: Int
-    public let plain_name: String?
-    public let size: Int
-    public let type: String
+    public let encryptVersion: String?
+    public let deleted: Bool
     // ISO string
-    public let updatedAt: String
-}
-
-public struct FetchFolderContentResponse: Decodable {
-    public let bucket: String?
-    public let children: Array<FolderChild>
-    public let files: Array<DriveFileData>
+    public let deletedAt: String?
+    public let userId: Int
+    public let modificationTime: String
     // ISO string
     public let createdAt: String
-    public let encrypt_version: String?
-    public let id: Int
-    public let name: String
-    public let plain_name: String?
-    public let parentId: Int?
-    public let parent_id: Int?
     // ISO string
     public let updatedAt: String
-    public let userId: Int
-    public let user_id: Int
+    public let plainName: String?
+    public let removed: Bool?
+    // ISO string
+    public let removedAt: String
+    public let status: String
 }
+
+public struct GetFolderFilesResponse: Decodable {
+    public let result: GetFolderFilesResult
+}
+
+struct GetFolderFoldersEndpoint: Endpoint {
+    var body: Data? = nil
+    let method =  HTTPMethod.GET
+    let path: String
+    init(path: String) {
+        self.path = path
+    }
+}
+
+public struct GetFolderFoldersResult: Decodable {
+    public let type: String
+    public let id: Int
+    public let parentId: Int
+    public let name: String
+    public let userId: Int
+    public let encryptVersion: String?
+    public let deleted: Bool
+    // ISO string
+    public let deletedAt: String?
+    // ISO string
+    public let createdAt: String?
+    // ISO string
+    public let updatedAt: String?
+    public let plainName: String?
+    public let removed: Bool
+    // ISO string
+    public let removedAt: String?
+}
+
+public struct GetFolderFoldersResponse: Decodable {
+    public let result: GetFolderFoldersResult
+}
+
 
 struct CreateFolderEndpoint: Endpoint {
     var body: Data?

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -8,15 +8,6 @@
 import Foundation
 
 
-struct GetFolderFilesEndpoint: Endpoint {
-    var body: Data? = nil
-    let method =  HTTPMethod.GET
-    let path: String
-    init(path: String) {
-        self.path = path
-    }
-}
-
 public struct GetFolderFilesResult: Decodable {
     public let id: Int
     public let fileId: String
@@ -47,14 +38,7 @@ public struct GetFolderFilesResponse: Decodable {
     public let result: Array<GetFolderFilesResult>
 }
 
-struct GetFolderFoldersEndpoint: Endpoint {
-    var body: Data? = nil
-    let method =  HTTPMethod.GET
-    let path: String
-    init(path: String) {
-        self.path = path
-    }
-}
+
 
 public struct GetFolderFoldersResult: Decodable {
     public let type: String
@@ -81,16 +65,6 @@ public struct GetFolderFoldersResponse: Decodable {
 }
 
 
-struct CreateFolderEndpoint: Endpoint {
-    var body: Data?
-    let method: HTTPMethod =  HTTPMethod.POST
-    let path: String
-    init(path: String, body: Data?) {
-        self.path = path
-        self.body = body
-    }
-}
-
 public struct CreateFolderPayload: Encodable {
     public let parentFolderId: Int
     public let folderName: String
@@ -112,16 +86,6 @@ public struct CreateFolderResponse: Decodable {
 }
 
 
-struct UpdateFolderEndpoint: Endpoint {
-    var body: Data?
-    let method: HTTPMethod =  HTTPMethod.POST
-    let path: String
-    init(path: String, body: Data?) {
-        self.path = path
-        self.body = body
-    }
-}
-
 public struct UpdateFolderResponse: Decodable {
     public let id: Int
     public let name: String
@@ -137,12 +101,24 @@ public struct UpdateFolderPayload: Encodable {
 }
 
 
-struct TrashFolderEndpoint: Endpoint {
-    var body: Data?
-    let method: HTTPMethod =  HTTPMethod.POST
-    let path: String
-    init(path: String, body: Data?) {
-        self.path = path
-        self.body = body
-    }
+public struct GetFolderMetaByIdResponse: Decodable {
+    public let id: Int
+    public let parentId: Int?
+    public let name: String
+    public let bucket: String?
+    public let userId: Int
+    public let encryptVersion: String?
+    public let deleted: Bool
+    // ISO Date
+    public let createdAt: String
+    public let updatedAt: String
+    public let deletedAt: String?
+    public let removedAt: String?
+    public let uuid: String?
+    public let plainName: String?
+    public let removed: Bool
+}
+
+public struct GetFileMetaByIdResponse: Decodable {
+   
 }

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -11,7 +11,7 @@ import Foundation
 public struct FolderChild: Decodable {
     // ISO string
     public let createdAt: String
-    public let encrypt_version: String
+    public let encrypt_version: String?
     public let id: Int
     public let name: String
     public let plain_name: String?
@@ -28,7 +28,7 @@ public struct DriveFileData: Decodable {
     public let createdAt: String
     public let created_at: String
     public let deleted: Bool
-    public let encrypt_version: String
+    public let encrypt_version: String?
     public let fileId: String
     public let folderId: Int
     public let folder_id: Int
@@ -47,7 +47,7 @@ public struct FetchFolderContentResponse: Decodable {
     public let files: Array<DriveFileData>
     // ISO string
     public let createdAt: String
-    public let encrypt_version: String
+    public let encrypt_version: String?
     public let id: Int
     public let name: String
     public let plain_name: String?

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -79,6 +79,11 @@ public struct CreateFolderResponse: Decodable {
     public let userId: Int
 }
 
-public struct UpdateFolderPayload: Encodable {
+public struct MetadataUpdatePayload: Encodable {
     public let itemName: String
+}
+
+
+public struct UpdateFolderPayload: Encodable {
+    public let metadata: MetadataUpdatePayload
 }

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -9,14 +9,9 @@ import Foundation
 
 
 public struct FolderChild: Decodable {
-    let bucket: String
-    let color: String?
     // ISO string
     let createdAt: String
     let encrypt_version: String
-    let icon: String?
-    let iconId: Int?
-    let icon_id: Int?
     let id: Int
     let name: String
     let plain_name: String?
@@ -50,7 +45,6 @@ public struct FetchFolderContentResponse: Decodable {
     let bucket: String?
     let children: Array<FolderChild>
     let files: Array<DriveFileData>
-    let color: String?
     // ISO string
     let createdAt: String
     let encrypt_version: String

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -8,6 +8,15 @@
 import Foundation
 
 
+struct GetFolderContentEndpoint: Endpoint {
+    var body: Data? = nil
+    let method =  HTTPMethod.GET
+    let path: String
+    init(path: String) {
+        self.path = path
+    }
+}
+
 public struct FolderChild: Decodable {
     // ISO string
     public let createdAt: String
@@ -59,6 +68,16 @@ public struct FetchFolderContentResponse: Decodable {
     public let user_id: Int
 }
 
+struct CreateFolderEndpoint: Endpoint {
+    var body: Data?
+    let method: HTTPMethod =  HTTPMethod.POST
+    let path: String
+    init(path: String, body: Data?) {
+        self.path = path
+        self.body = body
+    }
+}
+
 public struct CreateFolderPayload: Encodable {
     public let parentFolderId: Int
     public let folderName: String
@@ -79,6 +98,17 @@ public struct CreateFolderResponse: Decodable {
     public let userId: Int
 }
 
+
+struct UpdateFolderEndpoint: Endpoint {
+    var body: Data?
+    let method: HTTPMethod =  HTTPMethod.POST
+    let path: String
+    init(path: String, body: Data?) {
+        self.path = path
+        self.body = body
+    }
+}
+
 public struct UpdateFolderResponse: Decodable {
     public let id: Int
     public let name: String
@@ -91,4 +121,15 @@ public struct MetadataUpdatePayload: Encodable {
 
 public struct UpdateFolderPayload: Encodable {
     public let metadata: MetadataUpdatePayload
+}
+
+
+struct TrashFolderEndpoint: Endpoint {
+    var body: Data?
+    let method: HTTPMethod =  HTTPMethod.POST
+    let path: String
+    init(path: String, body: Data?) {
+        self.path = path
+        self.body = body
+    }
 }

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -1,0 +1,66 @@
+//
+//  DriveTypes.swift
+//  
+//
+//  Created by Robert Garcia on 6/8/23.
+//
+
+import Foundation
+
+
+struct FolderChild: Decodable {
+    let bucket: String
+    let color: String
+    // ISO string
+    let createdAt: String
+    let encrypt_version: String
+    let icon: String
+    let iconId: Int?
+    let icon_id: Int?
+    let id: Int
+    let name: String
+    let plain_name: String?
+    let parentId: Int
+    let parent_id: Int
+    let updatedAt: String
+    let userId: Int
+    let user_id: Int
+}
+
+struct DriveFileData: Decodable {
+    let bucket: String
+    // ISO string
+    let createdAt: String
+    let created_at: String
+    let deleted: Bool
+    let encrypt_version: String
+    let fileId: String
+    let folderId: Int
+    let folder_id: Int
+    let id: Int
+    let name: Int
+    let plain_name: String?
+    let size: Int
+    let type: String
+    // ISO string
+    let updatedAt: String
+}
+
+struct FetchFolderContentResponse: Decodable {
+    let bucket: String
+    let children: Array<FolderChild>
+    let files: Array<DriveFileData>
+    let color: String
+    // ISO string
+    let createdAt: String
+    let encrypt_version: String
+    let id: Int
+    let name: String
+    let plain_name: String?
+    let parentId: Int
+    let parent_id: Int
+    // ISO string
+    let updatedAt: String
+    let userId: Int
+    let user_id: Int
+}

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -67,9 +67,9 @@ public struct GetFolderFoldersResult: Decodable {
     // ISO string
     public let deletedAt: String?
     // ISO string
-    public let createdAt: String?
+    public let createdAt: String
     // ISO string
-    public let updatedAt: String?
+    public let updatedAt: String
     public let plainName: String?
     public let removed: Bool
     // ISO string

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -59,9 +59,13 @@ public struct FetchFolderContentResponse: Decodable {
     public let user_id: Int
 }
 
-public struct CreateFolderPayload: Codable {
+public struct CreateFolderPayload: Encodable {
     public let parentFolderId: Int
     public let folderName: String
+    init(parentFolderId: Int, folderName: String)  {
+        self.parentFolderId = parentFolderId
+        self.folderName = folderName
+    }
 }
 public struct CreateFolderResponse: Decodable {
     public let bucket: String

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -10,51 +10,51 @@ import Foundation
 
 public struct FolderChild: Decodable {
     // ISO string
-    let createdAt: String
-    let encrypt_version: String
-    let id: Int
-    let name: String
-    let plain_name: String?
-    let parentId: Int
-    let parent_id: Int
-    let updatedAt: String
-    let userId: Int
-    let user_id: Int
+    public let createdAt: String
+    public let encrypt_version: String
+    public let id: Int
+    public let name: String
+    public let plain_name: String?
+    public let parentId: Int
+    public let parent_id: Int
+    public let updatedAt: String
+    public let userId: Int
+    public let user_id: Int
 }
 
 public struct DriveFileData: Decodable {
-    let bucket: String
+    public let bucket: String
     // ISO string
-    let createdAt: String
-    let created_at: String
-    let deleted: Bool
-    let encrypt_version: String
-    let fileId: String
-    let folderId: Int
-    let folder_id: Int
-    let id: Int
-    let name: Int
-    let plain_name: String?
-    let size: Int
-    let type: String
+    public let createdAt: String
+    public let created_at: String
+    public let deleted: Bool
+    public let encrypt_version: String
+    public let fileId: String
+    public let folderId: Int
+    public let folder_id: Int
+    public let id: Int
+    public let name: Int
+    public let plain_name: String?
+    public let size: Int
+    public let type: String
     // ISO string
-    let updatedAt: String
+    public let updatedAt: String
 }
 
 public struct FetchFolderContentResponse: Decodable {
-    let bucket: String?
-    let children: Array<FolderChild>
-    let files: Array<DriveFileData>
+    public let bucket: String?
+    public let children: Array<FolderChild>
+    public let files: Array<DriveFileData>
     // ISO string
-    let createdAt: String
-    let encrypt_version: String
-    let id: Int
-    let name: String
-    let plain_name: String?
-    let parentId: Int?
-    let parent_id: Int?
+    public let createdAt: String
+    public let encrypt_version: String
+    public let id: Int
+    public let name: String
+    public let plain_name: String?
+    public let parentId: Int?
+    public let parent_id: Int?
     // ISO string
-    let updatedAt: String
-    let userId: Int
-    let user_id: Int
+    public let updatedAt: String
+    public let userId: Int
+    public let user_id: Int
 }

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 
-struct FolderChild: Decodable {
+public struct FolderChild: Decodable {
     let bucket: String
     let color: String
     // ISO string
@@ -27,7 +27,7 @@ struct FolderChild: Decodable {
     let user_id: Int
 }
 
-struct DriveFileData: Decodable {
+public struct DriveFileData: Decodable {
     let bucket: String
     // ISO string
     let createdAt: String
@@ -46,7 +46,7 @@ struct DriveFileData: Decodable {
     let updatedAt: String
 }
 
-struct FetchFolderContentResponse: Decodable {
+public struct FetchFolderContentResponse: Decodable {
     let bucket: String
     let children: Array<FolderChild>
     let files: Array<DriveFileData>

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -78,3 +78,7 @@ public struct CreateFolderResponse: Decodable {
     public let updatedAt: String
     public let userId: Int
 }
+
+public struct UpdateFolderPayload: Encodable {
+    public let itemName: String
+}

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -68,7 +68,7 @@ public struct CreateFolderPayload: Encodable {
     }
 }
 public struct CreateFolderResponse: Decodable {
-    public let bucket: String
+    public let bucket: String?
     public let id: Int
     public let name: String
     public let plain_name: String?

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-
 public struct GetFolderFilesResult: Decodable {
     public let id: Int
     public let fileId: String
@@ -37,8 +36,6 @@ public struct GetFolderFilesResult: Decodable {
 public struct GetFolderFilesResponse: Decodable {
     public let result: Array<GetFolderFilesResult>
 }
-
-
 
 public struct GetFolderFoldersResult: Decodable {
     public let type: String

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -51,8 +51,8 @@ public struct FetchFolderContentResponse: Decodable {
     let id: Int
     let name: String
     let plain_name: String?
-    let parentId: Int
-    let parent_id: Int
+    let parentId: Int?
+    let parent_id: Int?
     // ISO string
     let updatedAt: String
     let userId: Int

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -37,9 +37,9 @@ public struct GetFolderFilesResult: Decodable {
     // ISO string
     public let updatedAt: String
     public let plainName: String?
-    public let removed: Bool?
+    public let removed: Bool
     // ISO string
-    public let removedAt: String
+    public let removedAt: String?
     public let status: String
 }
 

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -10,11 +10,11 @@ import Foundation
 
 public struct FolderChild: Decodable {
     let bucket: String
-    let color: String
+    let color: String?
     // ISO string
     let createdAt: String
     let encrypt_version: String
-    let icon: String
+    let icon: String?
     let iconId: Int?
     let icon_id: Int?
     let id: Int
@@ -47,10 +47,10 @@ public struct DriveFileData: Decodable {
 }
 
 public struct FetchFolderContentResponse: Decodable {
-    let bucket: String
+    let bucket: String?
     let children: Array<FolderChild>
     let files: Array<DriveFileData>
-    let color: String
+    let color: String?
     // ISO string
     let createdAt: String
     let encrypt_version: String

--- a/Sources/InternxtSwiftCore/Types/NetworkTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/NetworkTypes.swift
@@ -7,24 +7,24 @@
 
 import Foundation
 
-struct NetworkUploadPayload: Codable {
+public struct NetworkUploadPayload: Codable {
     let index: Int
     let size: Int
 }
-struct StartUploadPayload: Codable {
+public struct StartUploadPayload: Codable {
     let uploads: Array<NetworkUploadPayload>
     
     
 }
 
-struct UploadResult: Decodable {
+public struct UploadResult: Decodable {
     let uuid: String
     let url: String?
     let urls: Array<String>
     let UploadId: String?
 }
 
-struct StartUploadEndpoint: Endpoint {
+public struct StartUploadEndpoint: Endpoint {
     let body: Codable?
     
     let method =  HTTPMethod.POST

--- a/Sources/InternxtSwiftCore/Types/NetworkTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/NetworkTypes.swift
@@ -27,6 +27,8 @@ public struct UploadResult: Decodable {
 public struct StartUploadEndpoint: Endpoint {
     var path: String
     
+    
+    
     let body: Codable?
     
     let method =  HTTPMethod.POST

--- a/Sources/InternxtSwiftCore/Types/NetworkTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/NetworkTypes.swift
@@ -25,11 +25,14 @@ public struct UploadResult: Decodable {
 }
 
 public struct StartUploadEndpoint: Endpoint {
+    var path: String
+    
     let body: Codable?
     
     let method =  HTTPMethod.POST
     
     init(body: Codable?) {
         self.body = body
+        self.path = ""
     }
 }

--- a/Sources/InternxtSwiftCore/Types/NetworkTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/NetworkTypes.swift
@@ -25,15 +25,14 @@ public struct UploadResult: Decodable {
 }
 
 public struct StartUploadEndpoint: Endpoint {
+    var body: Encodable?
+    
     var path: String
     
     
-    
-    let body: Codable?
-    
     let method =  HTTPMethod.POST
     
-    init(body: Codable?) {
+    init(body: Encodable?) {
         self.body = body
         self.path = ""
     }

--- a/Sources/InternxtSwiftCore/Types/NetworkTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/NetworkTypes.swift
@@ -25,14 +25,12 @@ public struct UploadResult: Decodable {
 }
 
 public struct StartUploadEndpoint: Endpoint {
-    var body: Encodable?
-    
     var path: String
-    
+    let body: Data?
     
     let method =  HTTPMethod.POST
     
-    init(body: Encodable?) {
+    init(body: Data?) {
         self.body = body
         self.path = ""
     }

--- a/Sources/InternxtSwiftCore/Types/NetworkTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/NetworkTypes.swift
@@ -8,30 +8,65 @@
 import Foundation
 
 public struct NetworkUploadPayload: Codable {
-    let index: Int
-    let size: Int
+    public let index: Int
+    public let size: Int
 }
+
 public struct StartUploadPayload: Codable {
-    let uploads: Array<NetworkUploadPayload>
-    
-    
+    public let uploads: Array<NetworkUploadPayload>
 }
 
-public struct UploadResult: Decodable {
-    let uuid: String
-    let url: String?
-    let urls: Array<String>
-    let UploadId: String?
+public struct StartUploadResponse: Decodable {
+    public let uuid: String
+    public let url: String?
+    public let urls: Array<String>
+    public let UploadId: String?
 }
 
-public struct StartUploadEndpoint: Endpoint {
-    var path: String
-    let body: Data?
-    
-    let method =  HTTPMethod.POST
-    
-    init(body: Data?) {
-        self.body = body
-        self.path = ""
-    }
+
+public struct ShardUploadPayload: Codable {
+    public let hash: String
+    public let uuid: String
+}
+
+
+public struct FinishUploadPayload: Codable {
+    public let index: String
+    public let shards: Array<ShardUploadPayload>
+}
+
+
+public struct FinishUploadResponse: Decodable {
+    public let bucket: String
+    public let index: String
+    public let size: Int
+    public let version: Int
+    // ISO Date
+    public let created: String
+    // ISO Date
+    public let renewal: String
+    public let mimetype: String
+    public let filename: String
+    public let id: String
+}
+
+public struct GetFileInfoShard: Decodable {
+    public let index: Int
+    public let hash: String
+    public let url: String
+}
+
+public struct GetFileInfoResponse: Decodable {
+    public let bucket: String
+    public let index: String
+    public let size: Int
+    public let version: Int
+    // ISO Date
+    public let created: String
+    // ISO Date
+    public let renewal: String
+    public let mimetype: String
+    public let filename: String
+    public let id: String
+    public let shards: Array<GetFileInfoShard>
 }

--- a/Sources/InternxtSwiftCore/Types/TrashTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/TrashTypes.swift
@@ -1,0 +1,38 @@
+//
+//  TrashTypes.swift
+//  
+//
+//  Created by Robert Garcia on 7/8/23.
+//
+
+import Foundation
+
+
+public struct AddItemsToTrashEndpoint: Endpoint {
+    var body: Data?
+    let method: HTTPMethod =  HTTPMethod.POST
+    let path: String
+    init(path: String, body: Data?) {
+        self.path = path
+        self.body = body
+    }
+}
+
+public enum ItemToTrashType: String {
+    case File = "file"
+    case Folder = "folder"
+}
+
+public struct ItemToTrash: Encodable {
+    public let id: Int
+    public let type: String
+    
+    init(id: Int, type: ItemToTrashType) {
+        self.id = id
+        self.type = type.rawValue
+    }
+}
+
+public struct AddItemsToTrashPayload: Encodable {
+    public let items: Array<ItemToTrash>
+}

--- a/Sources/InternxtSwiftCore/Types/TrashTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/TrashTypes.swift
@@ -36,3 +36,7 @@ public struct ItemToTrash: Encodable {
 public struct AddItemsToTrashPayload: Encodable {
     public let items: Array<ItemToTrash>
 }
+
+public struct AddItemsToTrashResponse: Decodable {
+    
+}

--- a/Sources/InternxtSwiftCore/Types/TrashTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/TrashTypes.swift
@@ -8,15 +8,7 @@
 import Foundation
 
 
-public struct AddItemsToTrashEndpoint: Endpoint {
-    var body: Data?
-    let method: HTTPMethod =  HTTPMethod.POST
-    let path: String
-    init(path: String, body: Data?) {
-        self.path = path
-        self.body = body
-    }
-}
+
 
 public enum ItemToTrashType: String {
     case File = "file"
@@ -41,6 +33,4 @@ public struct AddItemsToTrashPayload: Encodable {
     }
 }
 
-public struct AddItemsToTrashResponse: Decodable {
-    
-}
+public struct AddItemsToTrashResponse: Decodable {}

--- a/Sources/InternxtSwiftCore/Types/TrashTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/TrashTypes.swift
@@ -34,7 +34,11 @@ public struct ItemToTrash: Encodable {
 }
 
 public struct AddItemsToTrashPayload: Encodable {
-    public let items: Array<ItemToTrash>
+    private let items: Array<ItemToTrash>
+    
+    public init(items: Array<ItemToTrash>) {
+        self.items = items
+    }
 }
 
 public struct AddItemsToTrashResponse: Decodable {

--- a/Sources/InternxtSwiftCore/Types/TrashTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/TrashTypes.swift
@@ -7,9 +7,6 @@
 
 import Foundation
 
-
-
-
 public enum ItemToTrashType: String {
     case File = "file"
     case Folder = "folder"

--- a/Sources/InternxtSwiftCore/Types/TrashTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/TrashTypes.swift
@@ -27,7 +27,7 @@ public struct ItemToTrash: Encodable {
     public let id: Int
     public let type: String
     
-    init(id: Int, type: ItemToTrashType) {
+    public init(id: Int, type: ItemToTrashType) {
         self.id = id
         self.type = type.rawValue
     }

--- a/Sources/InternxtSwiftCore/Utils/ConfigLoader.swift
+++ b/Sources/InternxtSwiftCore/Utils/ConfigLoader.swift
@@ -16,7 +16,7 @@ public struct Config {
 var loadedConfig: Mirror? = nil
 
 
-struct ConfigLoader {
+public struct ConfigLoader {
     func load(config: Config) {
         loadedConfig = Mirror(reflecting: config)
     }

--- a/Sources/InternxtSwiftCore/Utils/CoreConfigLoader.swift
+++ b/Sources/InternxtSwiftCore/Utils/CoreConfigLoader.swift
@@ -1,5 +1,5 @@
 //
-//  ConfigLoader.swift
+//  CoreConfigLoader.swift
 //  
 //
 //  Created by Robert Garcia on 1/8/23.
@@ -16,7 +16,7 @@ public struct Config {
 var loadedConfig: Mirror? = nil
 
 
-public struct ConfigLoader {
+public struct CoreConfigLoader {
     func load(config: Config) {
         loadedConfig = Mirror(reflecting: config)
     }

--- a/Sources/InternxtSwiftCore/Utils/CryptoUtils.swift
+++ b/Sources/InternxtSwiftCore/Utils/CryptoUtils.swift
@@ -9,7 +9,7 @@ import Foundation
 import IDZSwiftCommonCrypto
 
 @available(macOS 10.15, *)
-struct CryptoUtils {
+public struct CryptoUtils {
     private let keyDerivation = KeyDerivation()
     private let hmac = HMAC()
     public func hexStringToBytes(_ hexString: String) -> [UInt8] {

--- a/Tests/InternxtSwiftCoreTests/Utils/ConfigLoaderTests.swift
+++ b/Tests/InternxtSwiftCoreTests/Utils/ConfigLoaderTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 final class ConfigLoaderTests: XCTestCase {
 
-    let sut = ConfigLoader()
+    let sut = CoreConfigLoader()
 
     func testMustSetAConfig() throws {
         XCTAssertThrowsError(try sut.getConfigProperty(configKey: "Hello"))


### PR DESCRIPTION
This PR provides 3 base clients to interact with Internxt APIs:


A base APIClient is included, the APIClient is just an abstraction on top of URLSession aiming to provide an API similar to Javascript `fetch()`


### Network API client
- Start upload request
- Finish upload request
- Get file info request

### Drive API client
- Get paginated files
- Get paginated folders
- Update folder metadata
- Create folder
- Get folder meta by id

### Trash API client
- Add items to trash