### PR TITLE
[PB-993]:v1 downloads support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "InternxtSwiftCore",
+    platforms: [
+        .macOS(.v10_15)
+    ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Sources/InternxtSwiftCore/Extensions/Sequence.swift
+++ b/Sources/InternxtSwiftCore/Extensions/Sequence.swift
@@ -7,8 +7,9 @@
 
 import Foundation
 
-@available(macOS 10.15, *)
 extension Sequence {
+    
+    @available(macOS 10.15, *)
     func asyncForEach(
         _ operation: (Element) async throws -> Void
     ) async rethrows {

--- a/Sources/InternxtSwiftCore/Extensions/Sequence.swift
+++ b/Sources/InternxtSwiftCore/Extensions/Sequence.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+
+@available(macOS 10.15, *)
 extension Sequence {
     func asyncForEach(
         _ operation: (Element) async throws -> Void

--- a/Sources/InternxtSwiftCore/Extensions/Sequence.swift
+++ b/Sources/InternxtSwiftCore/Extensions/Sequence.swift
@@ -1,0 +1,17 @@
+//
+//  Sequence.swift
+//  
+//
+//  Created by Robert Garcia on 21/6/24.
+//
+
+import Foundation
+extension Sequence {
+    func asyncForEach(
+        _ operation: (Element) async throws -> Void
+    ) async rethrows {
+        for element in self {
+            try await operation(element)
+        }
+    }
+}

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/NetworkAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/NetworkAPI.swift
@@ -51,4 +51,12 @@ public struct NetworkAPI {
         )
         return try await apiClient.fetch(type: GetFileInfoResponse.self, endpoint, debugResponse: debug)
     }
+    
+    public func getFileMirrors(bucketId: String, fileId: String, debug: Bool = false) async throws -> [FileMirrorShard] {
+        let endpoint = Endpoint(
+            path: "\(self.baseUrl)/buckets/\(bucketId)/files/\(fileId)?limit=3&skip=0",
+            method: .GET
+        )
+        return try await apiClient.fetch(type: [FileMirrorShard].self, endpoint, debugResponse: debug)
+    }
 }

--- a/Sources/InternxtSwiftCore/Services/Network/Download.swift
+++ b/Sources/InternxtSwiftCore/Services/Network/Download.swift
@@ -124,6 +124,11 @@ public class Download: NSObject {
                         if overwriteFile {
                             try FileManager.default.copyItem(at: localURL, to: destinationURL)
                         } else {
+                            let exists = FileManager.default.fileExists(atPath: destinationURL.path)
+                            
+                            if exists == false {
+                                FileManager.default.createFile(atPath: destinationURL.path, contents: nil)
+                            }
                             try self.appendToFile(origin: localURL, destination: destinationURL)
                         }
                         

--- a/Sources/InternxtSwiftCore/Services/Network/Download.swift
+++ b/Sources/InternxtSwiftCore/Services/Network/Download.swift
@@ -131,6 +131,7 @@ public class Download: NSObject {
                         
                         continuation.resume(returning: destinationURL)
                     } catch {
+                        print("Download error", error)
                         continuation.resume(throwing: DownloadError.FailedToCopyDownloadedURL)
                     }
                     

--- a/Sources/InternxtSwiftCore/Services/Network/Download.swift
+++ b/Sources/InternxtSwiftCore/Services/Network/Download.swift
@@ -136,7 +136,6 @@ public class Download: NSObject {
                         
                         continuation.resume(returning: destinationURL)
                     } catch {
-                        print("Download error", error)
                         continuation.resume(throwing: DownloadError.FailedToCopyDownloadedURL)
                     }
                     

--- a/Sources/InternxtSwiftCore/Services/Network/NetworkFacade.swift
+++ b/Sources/InternxtSwiftCore/Services/Network/NetworkFacade.swift
@@ -215,7 +215,7 @@ public struct NetworkFacade {
         return decryptedFileURL
     }
     
-    public func decryptFile(bucketId: String, destinationURL: URL, progressHandler: ProgressHandler, encryptedFileDownloadResult: DownloadResult) async throws -> URL {
+    public func decryptFile(bucketId: String, destinationURL: URL, progressHandler: ProgressHandler, encryptedFileDownloadResult: DownloadResult, ignoreHashMissmatchCheck: Bool = false) async throws -> URL {
         
         if encryptedFileDownloadResult.url.fileSize == 0 {
             throw NetworkFacadeError.FileIsEmpty
@@ -234,7 +234,7 @@ public struct NetworkFacade {
         
         
         let hashMatch = encryptedContentHash.toHexString() == encryptedFileDownloadResult.expectedContentHash
-        if hashMatch == false {
+        if hashMatch == false && ignoreHashMissmatchCheck != false {
             throw NetworkFacadeError.HashMissmatch
         }
         

--- a/Sources/InternxtSwiftCore/Types/NetworkTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/NetworkTypes.swift
@@ -92,3 +92,11 @@ public struct GetFileInfoResponse: Decodable {
     public let id: String
     public let shards: Array<GetFileInfoShard>?
 }
+
+
+public struct FileMirrorShard: Decodable {
+  public let index: Int
+  public let hash: String
+  public let size: Int
+  public let url: String
+}


### PR DESCRIPTION
Add support to v1 downloads, which are downloads prior to January 2022 and they work by providing pieces of the file in "mirrors", each mirror contains an URL to download the chunk of file, they later are merged together in the app, and decrypted as a normal file