### PR TITLE
[_]: feature/use-multipart-uploads-on-backups

### DIFF
--- a/Sources/InternxtSwiftCore/Services/Network/NetworkFacade.swift
+++ b/Sources/InternxtSwiftCore/Services/Network/NetworkFacade.swift
@@ -165,14 +165,20 @@ public struct NetworkFacade {
                 uploadMultipart: uploadMultipart,
                 uploadState: uploadState,
                 maxProgressPerPart: maxProgressPerPart,
-                progressHandler: { progress in
-                    progressHandler(Double(partIndex) / Double(parts) + progress * maxProgressPerPart)
-                },
+                progressHandler: { _ in },
                 uploadedPartsActor: uploadedPartsActor
             )
 
             operation.completionBlock = {
                 operation.clearMemory()
+                Task {
+                    
+                    let partsUploaded = await uploadedPartsActor.getUploadedPartsConfigs()
+                    let completedParts = partsUploaded.count
+                    let progress = Double(completedParts) / Double(parts) * 0.99
+                    progressHandler(progress)
+                }
+                
             }
 
             // Wait until the number of active operations is below the concurrency limit

--- a/Sources/InternxtSwiftCore/Services/Network/NetworkFacade.swift
+++ b/Sources/InternxtSwiftCore/Services/Network/NetworkFacade.swift
@@ -150,11 +150,6 @@ public struct NetworkFacade {
                 throw UploadError.UploadNotSuccessful
             }
 
-            if await uploadedPartsActor.isPartUploaded(partIndex: partIndex) {
-                partIndex += 1
-                return
-            }
-
             hasher.update(data: encryptedChunk)
 
             let uploadUrl = uploadUrls[partIndex]

--- a/Sources/InternxtSwiftCore/Services/Network/NetworkFacade.swift
+++ b/Sources/InternxtSwiftCore/Services/Network/NetworkFacade.swift
@@ -10,6 +10,7 @@ import CryptoKit
 
 let MULTIPART_MIN_SIZE = 100 * 1024 * 1024;
 let MULTIPART_CHUNK_SIZE = 50 * 1024 * 1024;
+let MAX_WAIT_TIME: TimeInterval = 3600
 
 
 @available(macOS 10.15, *)
@@ -114,12 +115,10 @@ public struct NetworkFacade {
         debug: Bool = false
     ) async throws -> FinishUploadResponse {
         var hasher = SHA256.init()
-        var accumulatedProgress = 0.0
         let parts = ceil(Double(fileSize) / Double(MULTIPART_CHUNK_SIZE))
+        let maxProgressPerPart: Double = 0.99 / parts
         
         let startUploadResult = try await uploadMultipart.start(bucketId: bucketId, fileSize: fileSize, parts: Int(parts))
-        
-        let maxProgressPerPart: Double = 0.99 / parts
         
         guard let uploadUrls = startUploadResult.urls else {
             throw UploadError.MissingUploadUrl
@@ -132,82 +131,51 @@ public struct NetworkFacade {
         
         let uploadedPartsActor = UploadedPartsActor()
         let uploadState = UploadState()
-        let semaphore = DispatchSemaphore(value: 6)
         
-        
-        func processEncryptedChunk(encryptedChunk: Data, partIndex: Int) async throws {
-            let uploadUrl = uploadUrls[partIndex]
-            var attempt = 0
-            let maxRetries = 3
-
-            if await uploadState.isAborted() {
-                throw UploadError.UploadNotSuccessful
-            }
-            
-            while attempt < maxRetries {
-                do {
-
-                    let etag = try await uploadMultipart.uploadPart(
-                        encryptedChunk: encryptedChunk,
-                        uploadUrl: uploadUrl,
-                        partIndex: partIndex
-                    ) { progress in
-                        accumulatedProgress += (progress * maxProgressPerPart) / 100
-                        progressHandler(accumulatedProgress)
-                    }
-                    let uploadedPartConfig = UploadedPartConfig(etag: etag, partNumber: partIndex + 1)
-                    await uploadedPartsActor.addUploadedPartConfig(uploadedPartConfig)
-                    return
-                } catch {
-                    attempt += 1
-            
-                    if attempt >= maxRetries {
-                        await uploadState.setAborted()
-                        throw UploadError.PartUploadFailed(partIndex: partIndex, error: error)
-                    }
-                }
-            }
+        var tasks: [Data] = []
+        try await encrypt.encryptFileIntoChunks(
+            chunkSizeInBytes: MULTIPART_CHUNK_SIZE,
+            totalBytes: fileSize,
+            inputStream: input,
+            key: fileKey,
+            iv: iv
+        ) { encryptedChunk in
+            hasher.update(data: encryptedChunk)
+            tasks.append(encryptedChunk)
         }
         
-        try await withThrowingTaskGroup(of: Void.self) { group in
-            var tasks: [Data] = []
-            try await encrypt.encryptFileIntoChunks(
-                chunkSizeInBytes: MULTIPART_CHUNK_SIZE,
-                totalBytes: fileSize,
-                inputStream: input,
-                key: fileKey,
-                iv: iv
-            ) { encryptedChunk in
-                hasher.update(data: encryptedChunk)
-                tasks.append(encryptedChunk)
+        let operationQueue = OperationQueue()
+        operationQueue.maxConcurrentOperationCount = 6
+        
+        for (index, encryptedChunk) in tasks.enumerated() {
+            if await uploadedPartsActor.isPartUploaded(partIndex: index) {
+                continue
             }
             
-            for (index, encryptedChunk) in tasks.enumerated() {
-                semaphore.wait()
-                
-                group.addTask {
-                    defer { semaphore.signal() }
-                    do {
-                        if await uploadState.isAborted() {
-                            throw UploadError.UploadNotSuccessful
-                        }
-                        try await processEncryptedChunk(encryptedChunk: encryptedChunk, partIndex: index)
-                    } catch {
-                        await uploadState.setAborted()
-                        throw error
-                    }
-                }     
-            }
-            
-            do {
-                 try await group.waitForAll()
-             } catch {
-                 throw error
-             }
+            let uploadUrl = uploadUrls[index]
+            let operation = UploadPartOperation(
+                encryptedChunk: encryptedChunk,
+                partIndex: index,
+                uploadUrl: uploadUrl,
+                uploadMultipart: uploadMultipart,
+                uploadState: uploadState,
+                maxProgressPerPart: maxProgressPerPart,
+                progressHandler: { progress in
+                    progressHandler(progress)
+                },
+                uploadedPartsActor: uploadedPartsActor
+            )
+            operationQueue.addOperation(operation)
+        }
+        
+        operationQueue.waitUntilAllOperationsAreFinished()
+        
+        if await uploadState.isAborted() {
+            operationQueue.cancelAllOperations()
+            throw UploadError.UploadNotSuccessful
         }
         
         let fileSHA256digest = hasher.finalize()
-        
         var sha256Hash = [UInt8]()
         fileSHA256digest.withUnsafeBytes { bytes in
             sha256Hash.append(contentsOf: bytes)
@@ -239,6 +207,10 @@ public struct NetworkFacade {
 
         func getUploadedPartsConfigs() -> [UploadedPartConfig] {
             return uploadedPartsConfigs
+        }
+        
+        func isPartUploaded(partIndex: Int) -> Bool {
+            return uploadedPartsConfigs.contains(where: { $0.partNumber == partIndex + 1 })
         }
     }
     
@@ -336,4 +308,99 @@ public struct NetworkFacade {
             throw NetworkFacadeError.DecryptionFailed
         }
     }
+    
+    class UploadPartOperation: AsyncOperation {
+        let encryptedChunk: Data
+        let partIndex: Int
+        let uploadUrl: String
+        let uploadMultipart: UploadMultipart
+        let uploadState: UploadState
+        let maxProgressPerPart: Double
+        let progressHandler: (Double) -> Void
+        let uploadedPartsActor: UploadedPartsActor
+        
+        init(
+            encryptedChunk: Data,
+            partIndex: Int,
+            uploadUrl: String,
+            uploadMultipart: UploadMultipart,
+            uploadState: UploadState,
+            maxProgressPerPart: Double,
+            progressHandler: @escaping (Double) -> Void,
+            uploadedPartsActor: UploadedPartsActor
+        ) {
+            self.encryptedChunk = encryptedChunk
+            self.partIndex = partIndex
+            self.uploadUrl = uploadUrl
+            self.uploadMultipart = uploadMultipart
+            self.uploadState = uploadState
+            self.maxProgressPerPart = maxProgressPerPart
+            self.progressHandler = progressHandler
+            self.uploadedPartsActor = uploadedPartsActor
+        }
+        
+        override func main() {
+            Task {
+                do {
+                    try await uploadPartWithRetry()
+                    completeOperation()
+                } catch {
+                    await uploadState.setAborted()
+                    completeOperation()
+                }
+            }
+        }
+        
+        private func uploadPartWithRetry() async throws {
+            var attempt = 0
+            let maxRetries = 3
+
+            while attempt < maxRetries {
+                if await uploadState.isAborted() {
+                    throw UploadError.UploadNotSuccessful
+                }
+
+                do {
+                  
+                    if !NetworkMonitor.shared.isConnected {
+                        let startTime = Date()
+
+                        while !NetworkMonitor.shared.isConnected {
+                            try await Task.sleep(nanoseconds: 20 * 1_000_000_000) // Check every 20 seconds
+                            if Date().timeIntervalSince(startTime) > MAX_WAIT_TIME {
+                                await uploadState.setAborted()
+                                throw UploadError.UploadNotSuccessful
+                            }
+                        }
+                    }
+                    
+                    let etag = try await uploadMultipart.uploadPart(
+                        encryptedChunk: encryptedChunk,
+                        uploadUrl: uploadUrl,
+                        partIndex: partIndex
+                    ) { progress in
+                        self.progressHandler(progress * self.maxProgressPerPart / 100)
+                    }
+
+                    let uploadedPartConfig = UploadedPartConfig(etag: etag, partNumber: partIndex + 1)
+                    await uploadedPartsActor.addUploadedPartConfig(uploadedPartConfig)
+                    return
+                }
+                catch {
+                    if let urlError = error as? URLError,
+                           urlError.code == .notConnectedToInternet || urlError.code == .networkConnectionLost  {
+                    }else {
+                        
+                        attempt += 1
+                        if attempt >= maxRetries {
+                            await uploadState.setAborted()
+                            throw UploadError.PartUploadFailed(partIndex: partIndex, error: error)
+                        }
+                    }
+
+                }
+            }
+        }
+    }
+
 }

--- a/Sources/InternxtSwiftCore/Services/Network/NetworkFacade.swift
+++ b/Sources/InternxtSwiftCore/Services/Network/NetworkFacade.swift
@@ -8,8 +8,8 @@
 import Foundation
 import CryptoKit
 
-let MULTIPART_MIN_SIZE = 700 * 1024 * 1024;
-let MULTIPART_CHUNK_SIZE = 200 * 1024 * 1024;
+let MULTIPART_MIN_SIZE = 100 * 1024 * 1024;
+let MULTIPART_CHUNK_SIZE = 50 * 1024 * 1024;
 
 
 @available(macOS 10.15, *)
@@ -129,20 +129,44 @@ public struct NetworkFacade {
         if uploadUrls.count != Int(parts) {
             throw UploadMultipartError.MorePartsThanUploadUrls
         }
+        
+        var uploadAborted = false
+        
         func processEncryptedChunk(encryptedChunk: Data, partIndex: Int, debug: Bool = false) async throws -> Void {
             
-            let uploadUrl = uploadUrls[partIndex]
-            let etag = try await uploadMultipart.uploadPart(encryptedChunk: encryptedChunk, uploadUrl: uploadUrl, partIndex: partIndex){progress in
-                accumulatedProgress += (progress * maxProgressPerPart) / 100
-                // Each part reports the max progress per part
-                progressHandler(accumulatedProgress)
+            guard !uploadAborted else {
+                throw UploadError.UploadNotSuccessful
             }
             
-            let uploadedPartConfig = UploadedPartConfig(
-                etag: etag, partNumber: partIndex + 1
-            )
+            let uploadUrl = uploadUrls[partIndex]
+            var attempt = 0
+            let maxRetries = 3
             
-            uploadedPartsConfigs.append(uploadedPartConfig)
+            
+            while attempt < maxRetries {
+                
+                do {
+                    let etag = try await uploadMultipart.uploadPart(
+                        encryptedChunk: encryptedChunk,
+                        uploadUrl: uploadUrl,
+                        partIndex: partIndex
+                    ) { progress in
+                        accumulatedProgress += (progress * maxProgressPerPart) / 100
+                        progressHandler(accumulatedProgress)
+                    }
+                    
+                    let uploadedPartConfig = UploadedPartConfig(
+                        etag: etag, partNumber: partIndex + 1
+                    )
+                    uploadedPartsConfigs.append(uploadedPartConfig)
+                    return
+                } catch {
+                    attempt += 1
+                    if attempt >= maxRetries {
+                        uploadAborted = true
+                        throw UploadError.PartUploadFailed(partIndex: partIndex, error: error)
+                    }                }
+            }
             
         }
         
@@ -153,6 +177,9 @@ public struct NetworkFacade {
             key: fileKey,
             iv: iv
         ){encryptedChunk in
+            guard !uploadAborted else {
+                throw UploadError.UploadNotSuccessful
+            }
             hasher.update(data: encryptedChunk)
             // If something fails here, the error is propagated
             // and the stream reading is stopped

--- a/Sources/InternxtSwiftCore/Services/Network/NetworkFacade.swift
+++ b/Sources/InternxtSwiftCore/Services/Network/NetworkFacade.swift
@@ -116,10 +116,9 @@ public struct NetworkFacade {
         var hasher = SHA256.init()
         var accumulatedProgress = 0.0
         let parts = ceil(Double(fileSize) / Double(MULTIPART_CHUNK_SIZE))
-        var partIndex = 0
-        var uploadedPartsConfigs: [UploadedPartConfig] = []
+        
         let startUploadResult = try await uploadMultipart.start(bucketId: bucketId, fileSize: fileSize, parts: Int(parts))
-        // We use 0.99 so we can determine when we reach the full 100%
+        
         let maxProgressPerPart: Double = 0.99 / parts
         
         guard let uploadUrls = startUploadResult.urls else {
@@ -130,22 +129,24 @@ public struct NetworkFacade {
             throw UploadMultipartError.MorePartsThanUploadUrls
         }
         
-        var uploadAborted = false
         
-        func processEncryptedChunk(encryptedChunk: Data, partIndex: Int, debug: Bool = false) async throws -> Void {
-            
-            guard !uploadAborted else {
-                throw UploadError.UploadNotSuccessful
-            }
-            
+        let uploadedPartsActor = UploadedPartsActor()
+        let uploadState = UploadState()
+        let semaphore = DispatchSemaphore(value: 6)
+        
+        
+        func processEncryptedChunk(encryptedChunk: Data, partIndex: Int) async throws {
             let uploadUrl = uploadUrls[partIndex]
             var attempt = 0
             let maxRetries = 3
-            
+
+            if await uploadState.isAborted() {
+                throw UploadError.UploadNotSuccessful
+            }
             
             while attempt < maxRetries {
-                
                 do {
+
                     let etag = try await uploadMultipart.uploadPart(
                         encryptedChunk: encryptedChunk,
                         uploadUrl: uploadUrl,
@@ -154,63 +155,103 @@ public struct NetworkFacade {
                         accumulatedProgress += (progress * maxProgressPerPart) / 100
                         progressHandler(accumulatedProgress)
                     }
-                    
-                    let uploadedPartConfig = UploadedPartConfig(
-                        etag: etag, partNumber: partIndex + 1
-                    )
-                    uploadedPartsConfigs.append(uploadedPartConfig)
+                    let uploadedPartConfig = UploadedPartConfig(etag: etag, partNumber: partIndex + 1)
+                    await uploadedPartsActor.addUploadedPartConfig(uploadedPartConfig)
                     return
                 } catch {
                     attempt += 1
-                    if attempt >= maxRetries {
-                        uploadAborted = true
-                        throw UploadError.PartUploadFailed(partIndex: partIndex, error: error)
-                    }                }
-            }
             
+                    if attempt >= maxRetries {
+                        await uploadState.setAborted()
+                        throw UploadError.PartUploadFailed(partIndex: partIndex, error: error)
+                    }
+                }
+            }
         }
         
-        try await encrypt.encryptFileIntoChunks(
-            chunkSizeInBytes: MULTIPART_CHUNK_SIZE,
-            totalBytes: fileSize,
-            inputStream: input,
-            key: fileKey,
-            iv: iv
-        ){encryptedChunk in
-            guard !uploadAborted else {
-                throw UploadError.UploadNotSuccessful
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            var tasks: [Data] = []
+            try await encrypt.encryptFileIntoChunks(
+                chunkSizeInBytes: MULTIPART_CHUNK_SIZE,
+                totalBytes: fileSize,
+                inputStream: input,
+                key: fileKey,
+                iv: iv
+            ) { encryptedChunk in
+                hasher.update(data: encryptedChunk)
+                tasks.append(encryptedChunk)
             }
-            hasher.update(data: encryptedChunk)
-            // If something fails here, the error is propagated
-            // and the stream reading is stopped
-            try await processEncryptedChunk(encryptedChunk: encryptedChunk, partIndex: partIndex)
-            partIndex += 1
+            
+            for (index, encryptedChunk) in tasks.enumerated() {
+                semaphore.wait()
+                
+                group.addTask {
+                    defer { semaphore.signal() }
+                    do {
+                        if await uploadState.isAborted() {
+                            throw UploadError.UploadNotSuccessful
+                        }
+                        try await processEncryptedChunk(encryptedChunk: encryptedChunk, partIndex: index)
+                    } catch {
+                        await uploadState.setAborted()
+                        throw error
+                    }
+                }     
+            }
+            
+            do {
+                 try await group.waitForAll()
+             } catch {
+                 throw error
+             }
         }
         
         let fileSHA256digest = hasher.finalize()
         
         var sha256Hash = [UInt8]()
-        fileSHA256digest.withUnsafeBytes {bytes in
+        fileSHA256digest.withUnsafeBytes { bytes in
             sha256Hash.append(contentsOf: bytes)
         }
         
         let fileHash = HMAC().ripemd160(message: Data(sha256Hash))
-        
         
         let finishUpload = try await uploadMultipart.finishUpload(
             bucketId: bucketId,
             fileHash: fileHash.toHexString(),
             uploadUuid: startUploadResult.uuid,
             uploadId: startUploadResult.UploadId!,
-            uploadedParts: uploadedPartsConfigs,
+            uploadedParts: await uploadedPartsActor.getUploadedPartsConfigs(),
             index: Data(index),
             debug: debug
         )
         
-        // Finish the progress
         progressHandler(1)
-        
         return finishUpload
+    }
+    
+    actor UploadedPartsActor {
+        private var uploadedPartsConfigs: [UploadedPartConfig] = []
+        
+        
+        func addUploadedPartConfig(_ partConfig: UploadedPartConfig) {
+            uploadedPartsConfigs.append(partConfig)
+        }
+
+        func getUploadedPartsConfigs() -> [UploadedPartConfig] {
+            return uploadedPartsConfigs
+        }
+    }
+    
+    actor UploadState {
+        var uploadAborted = false
+        
+        func setAborted() {
+            uploadAborted = true
+        }
+        
+        func isAborted() -> Bool {
+            return uploadAborted
+        }
     }
     
     public func downloadFile(bucketId: String, fileId: String, encryptedFileDestination: URL, destinationURL: URL, progressHandler: @escaping ProgressHandler, debug: Bool = false) async throws -> URL {

--- a/Sources/InternxtSwiftCore/Services/Network/NetworkFacade.swift
+++ b/Sources/InternxtSwiftCore/Services/Network/NetworkFacade.swift
@@ -132,7 +132,13 @@ public struct NetworkFacade {
         let uploadedPartsActor = UploadedPartsActor()
         let uploadState = UploadState()
         
-        var tasks: [Data] = []
+        input.open()
+        defer { input.close() }
+        
+        let operationQueue = OperationQueue()
+        operationQueue.maxConcurrentOperationCount = 6
+
+        var partIndex = 0
         try await encrypt.encryptFileIntoChunks(
             chunkSizeInBytes: MULTIPART_CHUNK_SIZE,
             totalBytes: fileSize,
@@ -140,32 +146,42 @@ public struct NetworkFacade {
             key: fileKey,
             iv: iv
         ) { encryptedChunk in
-            hasher.update(data: encryptedChunk)
-            tasks.append(encryptedChunk)
-        }
-        
-        let operationQueue = OperationQueue()
-        operationQueue.maxConcurrentOperationCount = 6
-        
-        for (index, encryptedChunk) in tasks.enumerated() {
-            if await uploadedPartsActor.isPartUploaded(partIndex: index) {
-                continue
+            guard await !uploadState.isAborted() else {
+                throw UploadError.UploadNotSuccessful
             }
-            
-            let uploadUrl = uploadUrls[index]
+
+            if await uploadedPartsActor.isPartUploaded(partIndex: partIndex) {
+                partIndex += 1
+                return
+            }
+
+            hasher.update(data: encryptedChunk)
+
+            let uploadUrl = uploadUrls[partIndex]
             let operation = UploadPartOperation(
                 encryptedChunk: encryptedChunk,
-                partIndex: index,
+                partIndex: partIndex,
                 uploadUrl: uploadUrl,
                 uploadMultipart: uploadMultipart,
                 uploadState: uploadState,
                 maxProgressPerPart: maxProgressPerPart,
                 progressHandler: { progress in
-                    progressHandler(progress)
+                    progressHandler(Double(partIndex) / Double(parts) + progress * maxProgressPerPart)
                 },
                 uploadedPartsActor: uploadedPartsActor
             )
+
+            operation.completionBlock = {
+                operation.clearMemory()
+            }
+
+            // Wait until the number of active operations is below the concurrency limit
+            while operationQueue.operationCount >= operationQueue.maxConcurrentOperationCount {
+                await Task.sleep(UInt64(100_000_000))
+            }
+
             operationQueue.addOperation(operation)
+            partIndex += 1
         }
         
         operationQueue.waitUntilAllOperationsAreFinished()
@@ -310,7 +326,7 @@ public struct NetworkFacade {
     }
     
     class UploadPartOperation: AsyncOperation {
-        let encryptedChunk: Data
+        var encryptedChunk: Data?
         let partIndex: Int
         let uploadUrl: String
         let uploadMultipart: UploadMultipart
@@ -373,9 +389,11 @@ public struct NetworkFacade {
                             }
                         }
                     }
-                    
+                    guard let chunk = encryptedChunk else {
+                        throw UploadError.MissingChunk
+                    }
                     let etag = try await uploadMultipart.uploadPart(
-                        encryptedChunk: encryptedChunk,
+                        encryptedChunk: chunk,
                         uploadUrl: uploadUrl,
                         partIndex: partIndex
                     ) { progress in
@@ -400,6 +418,10 @@ public struct NetworkFacade {
 
                 }
             }
+        }
+        
+        func clearMemory() {
+            encryptedChunk = nil
         }
     }
 

--- a/Sources/InternxtSwiftCore/Services/Network/UploadMultipart.swift
+++ b/Sources/InternxtSwiftCore/Services/Network/UploadMultipart.swift
@@ -49,7 +49,7 @@ public class UploadMultipart: NSObject {
     
     
     private var progressHandlersByTaskID = [Int : ProgressHandler]()
-    
+    private let progressHandlerStore = ProgressHandlerStore()
     init(networkAPI: NetworkAPI, urlSession: URLSession? = nil) {
         self.networkAPI = networkAPI
         super.init()
@@ -83,15 +83,19 @@ public class UploadMultipart: NSObject {
         
         var shards: Array<ShardUploadPayload> = Array()
         
-        let shardPayload = ShardUploadPayload(
-            hash: fileHash,
-            uuid: uploadUuid,
-            parts: uploadedParts.map{ uploadedPart in
-                return ShardPartPayload(
+        let sortedParts = uploadedParts
+            .map { uploadedPart in
+                ShardPartPayload(
                     ETag: uploadedPart.etag,
                     PartNumber: uploadedPart.partNumber
                 )
-            },
+            }
+            .sorted { $0.PartNumber < $1.PartNumber }
+
+        let shardPayload = ShardUploadPayload(
+            hash: fileHash,
+            uuid: uploadUuid,
+            parts: sortedParts,
             uploadId: uploadId
         )
         
@@ -144,9 +148,9 @@ public class UploadMultipart: NSObject {
                     continuation.resume(throwing: error)
                 }
             )
-            
-            if progressHandler != nil {
-                progressHandlersByTaskID[task.taskIdentifier] = progressHandler
+                        
+            Task {
+                await progressHandlerStore.setHandler(for: task.taskIdentifier, handler: progressHandler)
             }
             
             
@@ -157,3 +161,22 @@ public class UploadMultipart: NSObject {
     
     
 }
+
+actor ProgressHandlerStore {
+    private var handlers: [Int: ProgressHandler] = [:]
+    
+    func setHandler(for taskID: Int, handler: ProgressHandler?) {
+        if let handler = handler {
+            handlers[taskID] = handler
+        }
+    }
+    
+    func getHandler(for taskID: Int) -> ProgressHandler? {
+        return handlers[taskID]
+    }
+    
+    func removeHandler(for taskID: Int) {
+        handlers.removeValue(forKey: taskID)
+    }
+}
+

--- a/Sources/InternxtSwiftCore/Utils/AsyncOperation.swift
+++ b/Sources/InternxtSwiftCore/Utils/AsyncOperation.swift
@@ -1,0 +1,48 @@
+//
+//  File.swift
+//  
+//
+//  Created by Patricio Tovar on 8/1/25.
+//
+
+import Foundation
+
+class AsyncOperation: Operation {
+    private let lockQueue = DispatchQueue(label: "com.Internxt.SwiftCore.AsyncOperation", attributes: .concurrent)
+    private var _isExecuting: Bool = false
+    private var _isFinished: Bool = false
+    
+    override var isAsynchronous: Bool { true }
+    
+    override var isExecuting: Bool {
+        get { lockQueue.sync { _isExecuting } }
+        set {
+            willChangeValue(forKey: "isExecuting")
+            lockQueue.async(flags: .barrier) { self._isExecuting = newValue }
+            didChangeValue(forKey: "isExecuting")
+        }
+    }
+    
+    override var isFinished: Bool {
+        get { lockQueue.sync { _isFinished } }
+        set {
+            willChangeValue(forKey: "isFinished")
+            lockQueue.async(flags: .barrier) { self._isFinished = newValue }
+            didChangeValue(forKey: "isFinished")
+        }
+    }
+    
+    func completeOperation() {
+        isExecuting = false
+        isFinished = true
+    }
+    
+    override func start() {
+        if isCancelled {
+            completeOperation()
+            return
+        }
+        isExecuting = true
+        main()
+    }
+}

--- a/Sources/InternxtSwiftCore/Utils/Errors.swift
+++ b/Sources/InternxtSwiftCore/Utils/Errors.swift
@@ -40,7 +40,7 @@ enum ExtensionError: Swift.Error, Equatable {
     case InvalidHex
 }
 
-enum UploadError: Error {
+public enum UploadError: Error {
     case InvalidIndex
     case CannotGenerateFileHash
     case FailedToFinishUpload
@@ -48,6 +48,7 @@ enum UploadError: Error {
     case UploadNotSuccessful
     case UploadedSizeNotMatching
     case MissingEtag
+    case PartUploadFailed(partIndex: Int, error: Error)
 }
 
 

--- a/Sources/InternxtSwiftCore/Utils/Errors.swift
+++ b/Sources/InternxtSwiftCore/Utils/Errors.swift
@@ -48,6 +48,7 @@ public enum UploadError: Error, Equatable {
     case UploadNotSuccessful
     case UploadedSizeNotMatching
     case MissingEtag
+    case MissingChunk
     case PartUploadFailed(partIndex: Int, error: Error)
 
     public static func == (lhs: UploadError, rhs: UploadError) -> Bool {
@@ -58,6 +59,7 @@ public enum UploadError: Error, Equatable {
              (.MissingUploadUrl, .MissingUploadUrl),
              (.UploadNotSuccessful, .UploadNotSuccessful),
              (.UploadedSizeNotMatching, .UploadedSizeNotMatching),
+             (.MissingChunk, .MissingChunk),
              (.MissingEtag, .MissingEtag):
             return true
         case let (.PartUploadFailed(lhsPartIndex, lhsError), .PartUploadFailed(rhsPartIndex, rhsError)):

--- a/Sources/InternxtSwiftCore/Utils/Errors.swift
+++ b/Sources/InternxtSwiftCore/Utils/Errors.swift
@@ -40,7 +40,7 @@ enum ExtensionError: Swift.Error, Equatable {
     case InvalidHex
 }
 
-public enum UploadError: Error {
+public enum UploadError: Error, Equatable {
     case InvalidIndex
     case CannotGenerateFileHash
     case FailedToFinishUpload
@@ -49,6 +49,23 @@ public enum UploadError: Error {
     case UploadedSizeNotMatching
     case MissingEtag
     case PartUploadFailed(partIndex: Int, error: Error)
+
+    public static func == (lhs: UploadError, rhs: UploadError) -> Bool {
+        switch (lhs, rhs) {
+        case (.InvalidIndex, .InvalidIndex),
+             (.CannotGenerateFileHash, .CannotGenerateFileHash),
+             (.FailedToFinishUpload, .FailedToFinishUpload),
+             (.MissingUploadUrl, .MissingUploadUrl),
+             (.UploadNotSuccessful, .UploadNotSuccessful),
+             (.UploadedSizeNotMatching, .UploadedSizeNotMatching),
+             (.MissingEtag, .MissingEtag):
+            return true
+        case let (.PartUploadFailed(lhsPartIndex, lhsError), .PartUploadFailed(rhsPartIndex, rhsError)):
+            return lhsPartIndex == rhsPartIndex && lhsError.localizedDescription == rhsError.localizedDescription
+        default:
+            return false
+        }
+    }
 }
 
 

--- a/Sources/InternxtSwiftCore/Utils/NetworkMonitor.swift
+++ b/Sources/InternxtSwiftCore/Utils/NetworkMonitor.swift
@@ -1,0 +1,27 @@
+//
+//  File.swift
+//  
+//
+//  Created by Patricio Tovar on 8/1/25.
+//
+
+import Network
+
+public class NetworkMonitor {
+    static let shared = NetworkMonitor()
+    private let monitor = NWPathMonitor()
+    private let queue = DispatchQueue.global(qos: .background)
+    var isConnected: Bool = true
+
+    private init() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            self?.isConnected = path.status == .satisfied
+        }
+        monitor.start(queue: queue)
+    }
+
+    func stopMonitoring() {
+        monitor.cancel()
+    }
+}
+


### PR DESCRIPTION
In this PR the following changes were made:
Added retries when a part fails.
Use part sizes of 50MB
If the file is >100MB, use multipart uploads
Use taskgroup to upload up to 6 parts at the same time
Use actors to safely handle concurrency