### PR TITLE
Migration to new Folder API structure + Notifications endpoint

### DIFF
--- a/Sources/InternxtSwiftCore/Services/HttpAPI/BackupAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/BackupAPI.swift
@@ -58,13 +58,14 @@ public struct BackupAPI {
 
         return try await apiClient.fetch(type: DeviceAsFolder.self, endpoint, debugResponse: debug)
     }
-
-    public func getBackupChilds(folderId: String, offset: Int = 0, limit: Int = 50, sort: String = "ASC", debug: Bool = false) async throws -> GetFolderFoldersResponse {
-        return try await driveAPI.getFolderFolders(folderId: folderId, offset: offset, limit: limit, sort: sort, debug: debug)
+    
+    public func getBackupChilds(folderUuid: String, offset: Int = 0, limit: Int = 50, order: String = "ASC", debug: Bool = false) async throws -> GetFolderFoldersResponseNew {
+        return try await driveAPI.getFolderFolders(folderUuid: folderUuid, offset: offset, limit: limit, order: order, debug: debug)
     }
 
-    public func getBackupFiles(folderId: String, offset: Int = 0, limit: Int = 50, sort: String = "ASC", debug: Bool = false) async throws -> GetFolderFilesResponse {
-        return try await driveAPI.getFolderFiles(folderId: folderId, offset: offset, limit: limit, sort: sort, debug: debug)
+
+    public func getBackupFiles(folderUuid: String, offset: Int = 0, limit: Int = 50, order: String = "ASC", debug: Bool = false) async throws -> GetFolderFilesResponseNew {
+        return try await driveAPI.getFolderFiles(folderUuid: folderUuid, offset: offset, limit: limit, order: order, debug: debug)
     }
 
     public func createBackupFolder(parentFolderUuid: String, folderName: String, debug: Bool = false) async throws -> CreateFolderResponseNew {
@@ -89,5 +90,9 @@ public struct BackupAPI {
     
     public func getExistenceFileInFolderByPlainName(uuid: String, files: Array<ExistenceFile>, debug: Bool = false) async throws  -> ExistenceFilesResponse {
         return try await driveAPI.getExistenceFileInFolderByPlainName(uuid: uuid, files: files)
+    }
+    
+    public func getBackupFolderMeta(folderId: String, debug: Bool = false) async throws -> GetFolderMetaByIdResponse {
+        return try await driveAPI.getFolderMetaById(id: folderId, debug: debug)
     }
 }

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -41,6 +41,24 @@ public struct DriveAPI {
         return try await apiClient.fetch(type: GetFolderFoldersResponse.self, endpoint, debugResponse: debug)
     }
     
+    /// Get paginated files inside the given folder using uuid
+    public func getFolderFiles(folderUuid: String, offset: Int = 0, limit: Int = 50, order: String = "ASC", debug: Bool = false) async throws -> GetFolderFilesResponseNew {
+        
+        let query: String = "?limit=\(String(limit))&offset=\(String(offset))&order=\(order)"
+        let endpoint = Endpoint(path: "\(self.baseUrl)/folders/content/\(folderUuid)/files\(query)")
+        
+        return try await apiClient.fetch(type: GetFolderFilesResponseNew.self, endpoint, debugResponse: debug)
+    }
+    
+    /// Get paginated folders inside the given folder using uuid
+    public func getFolderFolders(folderUuid: String, offset: Int = 0, limit: Int = 50, order: String = "ASC", debug: Bool = false) async throws -> GetFolderFoldersResponseNew {
+        
+        let query: String = "?limit=\(String(limit))&offset=\(String(offset))&order=\(order)"
+        let endpoint = Endpoint(path: "\(self.baseUrl)/folders/content/\(folderUuid)/folders\(query)")
+        
+        return try await apiClient.fetch(type: GetFolderFoldersResponseNew.self, endpoint, debugResponse: debug)
+    }
+    
     
     /// Creates a folder inside the given parentFolderId with the given name
     public func createFolder(parentFolderId: Int, folderName: String, debug: Bool = false) async throws -> CreateFolderResponse {

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/NotificationsAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/NotificationsAPI.swift
@@ -24,13 +24,13 @@ public struct NotificationsAPI {
     }
     
     
-    public func getNotifications(debug: Bool = false) async throws -> GetNotificationsResponse {
+    public func getNotifications(debug: Bool = false) async throws -> [GetNotificationsResponse] {
         let endpoint = Endpoint(
             path: "\(self.baseUrl)/notifications",
             method: .GET
         )
         
-        return try await apiClient.fetch(type: GetNotificationsResponse.self, endpoint, debugResponse: debug)
+        return try await apiClient.fetch(type: [GetNotificationsResponse].self, endpoint, debugResponse: debug)
     }
     
 }

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/NotificationsAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/NotificationsAPI.swift
@@ -26,7 +26,7 @@ public struct NotificationsAPI {
     
     public func getNotifications(debug: Bool = false) async throws -> GetNotificationsResponse {
         let endpoint = Endpoint(
-            path: "\(self.baseUrl)/drive/notifications",
+            path: "\(self.baseUrl)/notifications",
             method: .GET
         )
         

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -38,6 +38,10 @@ public struct GetFolderFilesResponse: Decodable {
     public let result: Array<GetFolderFilesResult>
 }
 
+public struct GetFolderFilesResponseNew: Decodable {
+    public let files: Array<GetFolderFilesResult>
+}
+
 public struct GetFolderFoldersResult: Decodable {
     public let type: String?
     public let id: Int
@@ -63,6 +67,11 @@ public struct GetFolderFoldersResult: Decodable {
 public struct GetFolderFoldersResponse: Decodable {
     public let result: Array<GetFolderFoldersResult>
 }
+
+public struct GetFolderFoldersResponseNew: Decodable {
+    public let folders: Array<GetFolderFoldersResult>
+}
+
 
 
 public struct CreateFolderPayload: Encodable {

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -732,7 +732,7 @@ public struct GetNotificationsResponse: Codable {
     public let id: String
     public let link: String
     public let message: String
-    public let expiresAt: String
+    public let expiresAt: String?
     public let createdAt: String
     public let deliveredAt: String
     public let readAt: String


### PR DESCRIPTION
This PR migrates the folder API integration to the new endpoint structure and response format, and adds support for the notifications endpoint.

Endpoint Updates
- **Old**: `/folders/{id}/folders` and `/folders/{id}/files`
- **New**: `/folders/content/{uuid}/folders` and `/folders/content/{uuid}/files`


New Features
-  `getNotifications()` - New method to fetch user notifications from `/notifications` endpoint