### PR TITLE
fix : add new functions to support optional file id and avoid errors

### DIFF
--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -50,6 +50,15 @@ public struct DriveAPI {
         return try await apiClient.fetch(type: GetFolderFilesResponseNew.self, endpoint, debugResponse: debug)
     }
     
+    
+    public func getFolderFilesV2(folderUuid: String, offset: Int = 0, limit: Int = 50, order: String = "ASC", debug: Bool = false) async throws -> GetFolderFilesResponseV2 {
+        
+        let query: String = "?limit=\(String(limit))&offset=\(String(offset))&order=\(order)"
+        let endpoint = Endpoint(path: "\(self.baseUrl)/folders/content/\(folderUuid)/files\(query)")
+        
+        return try await apiClient.fetch(type: GetFolderFilesResponseV2.self, endpoint, debugResponse: debug)
+    }
+    
     /// Get paginated folders inside the given folder using uuid
     public func getFolderFolders(folderUuid: String, offset: Int = 0, limit: Int = 50, order: String = "ASC", debug: Bool = false) async throws -> GetFolderFoldersResponseNew {
         
@@ -209,6 +218,16 @@ public struct DriveAPI {
         )
         
         return try await apiClient.fetch(type: GetFileMetaByIdResponse.self, endpoint, debugResponse: debug)
+    }
+    
+    /// Get file with fileid optional
+    public func getFileMetaByUuidV2(uuid: String, debug: Bool = false)  async throws -> GetFileMetaByIdResponseV2 {
+        let endpoint = Endpoint(
+            path: "\(self.baseUrl)/files/\(uuid)/meta",
+            method: .GET
+        )
+        
+        return try await apiClient.fetch(type: GetFileMetaByIdResponseV2.self, endpoint, debugResponse: debug)
     }
     
     public func moveFile(fileId: String, bucketId: String, destinationFolder: Int, debug: Bool = false) async throws -> MoveFileResponse {

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -34,12 +34,43 @@ public struct GetFolderFilesResult: Decodable {
     public let uuid: String
 }
 
+public struct GetFolderFilesResultV2: Decodable {
+    public let id: Int
+    public let fileId: String?
+    public let name: String
+    public let type: String?
+    // Size string in bytes
+    public let size: String
+    public let bucket: String
+    public let folderId: Int
+    public let encryptVersion: String?
+    public let deleted: Bool?
+    // ISO string
+    public let deletedAt: String?
+    public let userId: Int
+    public let modificationTime: String
+    // ISO string
+    public let createdAt: String
+    // ISO string
+    public let updatedAt: String
+    public let plainName: String?
+    public let removed: Bool?
+    // ISO string
+    public let removedAt: String?
+    public let status: String
+    public let uuid: String
+}
+
 public struct GetFolderFilesResponse: Decodable {
     public let result: Array<GetFolderFilesResult>
 }
 
 public struct GetFolderFilesResponseNew: Decodable {
     public let files: Array<GetFolderFilesResult>
+}
+
+public struct GetFolderFilesResponseV2: Decodable {
+    public let files: Array<GetFolderFilesResultV2>
 }
 
 public struct GetFolderFoldersResult: Decodable {
@@ -182,6 +213,28 @@ public struct GetFolderMetaByIdResponse: Decodable {
 public struct GetFileMetaByIdResponse: Decodable {
     public let id: Int
     public let fileId: String
+    public let folderId: Int
+    public let name: String
+    public let type: String?
+    public let size: String
+    public let bucket: String
+    public let deleted: Bool?
+    public let deletedAt: String?
+    public let userId: Int
+    public let modificationTime: String
+    public let createdAt: String
+    public let updatedAt: String
+    public let uuid: String
+    public let plainName: String?
+    public let removed: Bool?
+    public let removedAt: String?
+    public let status: String
+    public let folderUuid: String?
+}
+
+public struct GetFileMetaByIdResponseV2: Decodable {
+    public let id: Int
+    public let fileId: String?
     public let folderId: Int
     public let name: String
     public let type: String?
@@ -363,7 +416,7 @@ public struct CreateFileResponseNew: Decodable {
     public let type: String?
     public let size: String?
     public let folderId: Int
-    public let fileId: String
+    public let fileId: String?
     public let bucket: String
     public let encrypt_version: String
     public let userId: Int


### PR DESCRIPTION
This PR introduces new functions to support an optional fileId when downloading files and listing files with a size of 0, helping prevent errors caused by mandatory fileId validation.