### PR TITLE
fix: Use ephemeral URLSession to prevent stale DNS resolution

### DIFF
--- a/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/APIClient/APIClient.swift
@@ -231,6 +231,15 @@ private class DateFormatterCache {
 
 @available(macOS 10.15, *)
 struct APIClient {
+    /// Shared ephemeral URLSession that avoids DNS and HTTP caching.
+    public static let ephemeralSession: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.urlCache = nil
+        config.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        config.httpCookieStorage = nil
+        return URLSession(configuration: config)
+    }()
+    
     var urlSession: URLSession
     var authorizationHeaderValue: String? = nil
     var clientName: String? = nil
@@ -245,7 +254,7 @@ struct APIClient {
     private let semaphore: BoundedAsyncSemaphore
     
     init(
-        urlSession: URLSession = .shared,
+        urlSession: URLSession = APIClient.ephemeralSession,
         authorizationHeaderValue: String? = nil,
         clientName: String? = nil,
         clientVersion: String? = nil,

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/BackupAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/BackupAPI.swift
@@ -15,7 +15,7 @@ public struct BackupAPI {
 
     public init(baseUrl: String, authToken: String, clientName: String, clientVersion: String, gatewayHeader: String? = nil) {
         self.baseUrl = baseUrl
-        self.apiClient = APIClient(urlSession: URLSession.shared, authorizationHeaderValue: "Bearer \(authToken)", clientName: clientName, clientVersion: clientVersion
+        self.apiClient = APIClient(urlSession: APIClient.ephemeralSession, authorizationHeaderValue: "Bearer \(authToken)", clientName: clientName, clientVersion: clientVersion
             ,authorizationHeaderGatewayValue: gatewayHeader)
         self.driveAPI = DriveAPI(baseUrl: baseUrl, authToken: authToken, clientName: clientName, clientVersion: clientVersion)
     }

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -15,7 +15,7 @@ public struct DriveAPI {
     private let clientVersion: String
     public init(baseUrl: String, authToken: String, clientName: String, clientVersion: String, workspaceHeader: String? = nil, gatewayHeader: String? = nil) {
         self.baseUrl = baseUrl
-        self.apiClient = APIClient(urlSession: URLSession.shared, authorizationHeaderValue: "Bearer \(authToken)", clientName: clientName, 
+        self.apiClient = APIClient(urlSession: APIClient.ephemeralSession, authorizationHeaderValue: "Bearer \(authToken)", clientName: clientName, 
             clientVersion: clientVersion,
             workspaceHeader: workspaceHeader,
             authorizationHeaderGatewayValue: gatewayHeader
@@ -325,7 +325,7 @@ public struct DriveAPI {
 
     public func refreshUser(currentAuthToken: String, debug: Bool = false) async throws -> RefreshUserResponse  {
         
-        let apiClient = APIClient(urlSession: URLSession.shared, authorizationHeaderValue: "Bearer \(currentAuthToken)", clientName: clientName, clientVersion: clientVersion)
+        let apiClient = APIClient(urlSession: APIClient.ephemeralSession, authorizationHeaderValue: "Bearer \(currentAuthToken)", clientName: clientName, clientVersion: clientVersion)
         let endpoint = Endpoint(
             path: "\(self.baseUrl)/users/refresh",
             method: .GET
@@ -336,7 +336,7 @@ public struct DriveAPI {
     
     public func refreshTokens(currentAuthToken: String, debug: Bool = false) async throws -> RefreshTokensResponse  {
         
-        let apiClient = APIClient(urlSession: URLSession.shared, authorizationHeaderValue: "Bearer \(currentAuthToken)", clientName: clientName, clientVersion: clientVersion)
+        let apiClient = APIClient(urlSession: APIClient.ephemeralSession, authorizationHeaderValue: "Bearer \(currentAuthToken)", clientName: clientName, clientVersion: clientVersion)
         let endpoint = Endpoint(
             path: "\(self.baseUrl)/users/refresh",
             method: .GET
@@ -448,7 +448,7 @@ public struct DriveAPI {
     
     public func registerPushDeviceToken(currentAuthToken: String, deviceToken: String, type: String, debug: Bool = false) async throws -> PushDeviceTokenResponse  {
         
-        let apiClient = APIClient(urlSession: URLSession.shared, authorizationHeaderValue: "Bearer \(currentAuthToken)", clientName: clientName, clientVersion: clientVersion)
+        let apiClient = APIClient(urlSession: APIClient.ephemeralSession, authorizationHeaderValue: "Bearer \(currentAuthToken)", clientName: clientName, clientVersion: clientVersion)
         let endpoint = Endpoint(
             path: "\(self.baseUrl)/users/notification-token",
             method: .POST,

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/NetworkAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/NetworkAPI.swift
@@ -13,10 +13,10 @@ public struct NetworkAPI {
     private let baseUrl: String
     private let apiClient: APIClient
 
-    public init(baseUrl: String, basicAuthToken: String, urlSession: URLSession = URLSession.shared, clientName: String, clientVersion: String, gatewayHeader: String? = nil) {
+    public init(baseUrl: String, basicAuthToken: String, urlSession: URLSession? = nil, clientName: String, clientVersion: String, gatewayHeader: String? = nil) {
         self.baseUrl = baseUrl
-        
-        self.apiClient = APIClient(urlSession: urlSession, authorizationHeaderValue: "Basic \(basicAuthToken)", clientName: clientName, clientVersion: clientVersion,
+        let session = urlSession ?? APIClient.ephemeralSession
+        self.apiClient = APIClient(urlSession: session, authorizationHeaderValue: "Basic \(basicAuthToken)", clientName: clientName, clientVersion: clientVersion,
                                    authorizationHeaderGatewayValue: gatewayHeader)
     }
     

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/NotificationsAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/NotificationsAPI.swift
@@ -15,7 +15,7 @@ public struct NotificationsAPI {
     private let clientVersion: String
     public init(baseUrl: String, authToken: String, clientName: String, clientVersion: String, gatewayHeader: String? = nil) {
         self.baseUrl = baseUrl
-        self.apiClient = APIClient(urlSession: URLSession.shared, authorizationHeaderValue: "Bearer \(authToken)", clientName: clientName,
+        self.apiClient = APIClient(urlSession: APIClient.ephemeralSession, authorizationHeaderValue: "Bearer \(authToken)", clientName: clientName,
                                    clientVersion: clientVersion,
                                    authorizationHeaderGatewayValue: gatewayHeader
         )

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/PhotosAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/PhotosAPI.swift
@@ -14,7 +14,7 @@ public struct PhotosAPI {
     
     public init(baseUrl: String, authToken: String, clientName: String, clientVersion: String) {
         self.baseUrl = baseUrl
-        self.apiClient = APIClient(urlSession: URLSession.shared, authorizationHeaderValue: "Bearer \(authToken)", clientName: clientName, clientVersion: clientVersion)
+        self.apiClient = APIClient(urlSession: APIClient.ephemeralSession, authorizationHeaderValue: "Bearer \(authToken)", clientName: clientName, clientVersion: clientVersion)
     }
     
     public func getUsage(debug: Bool = false) async throws -> GetPhotosUsageResponse {

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/TrashAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/TrashAPI.swift
@@ -15,7 +15,7 @@ public struct TrashAPI {
     public init(baseUrl: String, authToken: String, clientName: String, clientVersion: String,workspaceHeader: String? = nil
     ,gatewayHeader: String? = nil) {
         self.baseUrl = baseUrl
-        self.apiClient = APIClient(urlSession: URLSession.shared, authorizationHeaderValue: "Bearer \(authToken)",clientName: clientName, clientVersion: clientVersion,workspaceHeader: workspaceHeader,
+        self.apiClient = APIClient(urlSession: APIClient.ephemeralSession, authorizationHeaderValue: "Bearer \(authToken)",clientName: clientName, clientVersion: clientVersion,workspaceHeader: workspaceHeader,
             authorizationHeaderGatewayValue: gatewayHeader)
     }
     

--- a/Sources/InternxtSwiftCore/Services/Network/Download.swift
+++ b/Sources/InternxtSwiftCore/Services/Network/Download.swift
@@ -45,7 +45,7 @@ public class Download: NSObject {
         if let urlSession = urlSession {
             self.urlSession = urlSession
         } else {
-            self.urlSession = URLSession.shared
+            self.urlSession = APIClient.ephemeralSession
         }
         
         super.init()


### PR DESCRIPTION
Replaced `URLSession.shared` with a shared **ephemeral** `URLSession`
(`APIClient.ephemeralSession`) across the entire networking layer.