### PR TITLE
fix: handle zero-size files in open browser by making fileId optional

### DIFF
--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -438,7 +438,7 @@ public struct DriveAPI {
     public func getFolderOrFileMetaById(id: String, debug: Bool = false) async throws -> GetDriveItemMetaByIdResponse {
         
         if UUID(uuidString: id) != nil{
-            let fileMeta = try await getFileMetaByUuid(uuid: id)
+            let fileMeta = try await getFileMetaByUuidV2(uuid: id)
             return DriveUtils.convertFileMetaToUnified(fileMeta: fileMeta)
         }
         let folderMeta = try await getFolderMetaById(id: id)

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -611,7 +611,7 @@ public struct GetDriveItemMetaByIdResponse: Decodable {
     public let status: String?
     
     public var isFolder: Bool {
-        return fileId == nil
+        return type == "folder"
     }
     
 }

--- a/Sources/InternxtSwiftCore/Utils/DriveUtils.swift
+++ b/Sources/InternxtSwiftCore/Utils/DriveUtils.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public struct DriveUtils {
     
-    static func convertFileMetaToUnified(fileMeta: GetFileMetaByIdResponse) -> GetDriveItemMetaByIdResponse {
+    static func convertFileMetaToUnified(fileMeta: GetFileMetaByIdResponseV2) -> GetDriveItemMetaByIdResponse {
         return GetDriveItemMetaByIdResponse(
             id: fileMeta.id,
             parentId: nil,
@@ -51,7 +51,7 @@ public struct DriveUtils {
             plainName: folderMeta.plainName,
             removed: folderMeta.removed,
             folderId: nil,
-            type: nil,
+            type: "folder",
             size: nil,
             fileId: nil,
             modificationTime: nil,


### PR DESCRIPTION
## Problem
When trying to open a file using the "Open Browser" feature, files with 
size 0 were failing silently. The root cause was that `fileId` was not 
being sent in the response for zero-size files, but the field was mapped 
as required in the response structure, causing the value to not be 
mapped correctly.

## Changes
- Make `fileId` optional in the response structure to handle cases where 
  it may not be present (e.g. zero-size files)
- Switch to v2 response format when `fileId` supports optional parameter
- Adjust folder item condition to align with the new optional handling