### PR TITLE
Make fileId optional to prevent decoding errors

### DIFF
--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -582,7 +582,7 @@ public struct ReplaceFileResponse: Decodable {
 public struct GetFileInFolderByPlainNameResponse: Decodable {
     public let id: Int
     public let uuid: String
-    public let fileId: String
+    public let fileId: String?
     public let name: String?
     public let type: String?
 }


### PR DESCRIPTION
Make fileId optional to prevent decoding errors