### PR TITLE
 Fix thread-safety crash and multipart upload deadlock

### DIFF
--- a/Sources/InternxtSwiftCore/Services/Network/NetworkFacade.swift
+++ b/Sources/InternxtSwiftCore/Services/Network/NetworkFacade.swift
@@ -254,7 +254,11 @@ public struct NetworkFacade {
             partIndex += 1
         }
         
-        operationQueue.waitUntilAllOperationsAreFinished()
+        await withCheckedContinuation { continuation in
+            operationQueue.addBarrierBlock {
+                continuation.resume()
+            }
+        }
         
         if await uploadState.isAborted() {
             operationQueue.cancelAllOperations()

--- a/Sources/InternxtSwiftCore/Services/Network/Upload.swift
+++ b/Sources/InternxtSwiftCore/Services/Network/Upload.swift
@@ -21,7 +21,9 @@ extension Upload: URLSessionTaskDelegate {
             totalBytesExpectedToSend: Int64
     ) {
             let progress = Double(totalBytesSent) / Double(totalBytesExpectedToSend)
+            progressHandlersLock.lock()
             let handler = progressHandlersByTaskID[task.taskIdentifier]
+            progressHandlersLock.unlock()
             handler?(progress)
     }
 }
@@ -46,6 +48,7 @@ public class Upload: NSObject  {
         )
     }()
     
+    private let progressHandlersLock = NSLock()
     private var progressHandlersByTaskID = [Int : ProgressHandler]()
 
     init(networkAPI: NetworkAPI, urlSession: URLSession? = nil, reduceBandwidth: Bool = false) {
@@ -250,10 +253,18 @@ public class Upload: NSObject  {
             
             request.httpMethod = "PUT"
             
+            var taskRef: URLSessionUploadTask? = nil
+            
             let task = urlSession.uploadTask(
                 with: request,
                 fromFile: encryptedFile,
-                completionHandler: { data, res, error in
+                completionHandler: { [weak self] data, res, error in
+                    if let self = self, let id = taskRef?.taskIdentifier {
+                        self.progressHandlersLock.lock()
+                        self.progressHandlersByTaskID.removeValue(forKey: id)
+                        self.progressHandlersLock.unlock()
+                    }
+                    
                     guard let error = error else {
                         let response = res as? HTTPURLResponse
                         if response?.statusCode != 200 {
@@ -268,8 +279,12 @@ public class Upload: NSObject  {
                 }
             )
             
+            taskRef = task
+            
             if progressHandler != nil {
+                progressHandlersLock.lock()
                 progressHandlersByTaskID[task.taskIdentifier] = progressHandler
+                progressHandlersLock.unlock()
             }
             
             


### PR DESCRIPTION
Problem
Two issues discovered under high-concurrency backup workloads:

EXC_BAD_ACCESS in Upload.uploadEncryptedFile — The progressHandlersByTaskID dictionary is accessed from multiple threads without synchronization. When 10 uploads write to it simultaneously, the dictionary's internal buffer can be reallocated mid-access, causing a segfault.

Multipart upload deadlock in NetworkFacade.runMultipartUpload — waitUntilAllOperationsAreFinished() is a blocking call that holds the current OS thread indefinitely. When multiple large files (>100MB) trigger multipart uploads concurrently, all threads in Swift's cooperative thread pool get blocked, leaving no threads available to execute the actual upload part operations → deadlock.

Solution
Made progressHandlersByTaskID thread-safe using NSLock and added cleanup on completion to prevent memory leaks.
Avoided retain cycles by using [weak self] and a taskRef pattern.
Replaced a blocking operationQueue.waitUntilAllOperationsAreFinished() with an async-safe alternative using withCheckedContinuation, preventing thread pool exhaustion.

