### PR TITLE
feat: Add Share API endpoints and AES-256-GCM cipher for public links

### DIFF
--- a/Sources/InternxtSwiftCore/Services/Crypto/InternxtAESCipher.swift
+++ b/Sources/InternxtSwiftCore/Services/Crypto/InternxtAESCipher.swift
@@ -1,0 +1,124 @@
+//
+//  InternxtAESCipher.swift
+//  InternxtSwiftCore
+//
+//  Created by Patricio Tovar on 6/5/26.
+//
+
+import Foundation
+import CryptoKit
+
+public enum InternxtAESError: Error {
+    case invalidCipherBase64
+    case invalidPayloadLength
+    case decryptionFailed
+    case randomBytesFailed
+}
+
+@available(macOS 10.15, *)
+public struct InternxtAESCipher {
+    
+   
+    private let iterations = 2145
+    private let keyLength = 32
+    private let saltLength = 64
+    private let ivLength = 16
+    private let tagLength = 16
+
+    public init() {}
+
+    /// Encrypts a plaintext string using AES-256-GCM and PBKDF2-HMAC-SHA512 derivation.
+    ///
+    /// - Parameters:
+    ///   - plaintext: The text to encrypt.
+    ///   - password: The password used for key derivation.
+    /// - Returns: Standard Base64 encoded string: `[ salt(64) | iv(16) | tag(16) | ciphertext(N) ]`
+    public func encrypt(plaintext: String, password: String) throws -> String {
+        let plaintextData = Data(plaintext.utf8)
+        
+        var salt = [UInt8](repeating: 0, count: saltLength)
+        let status1 = SecRandomCopyBytes(kSecRandomDefault, saltLength, &salt)
+        guard status1 == errSecSuccess else { throw InternxtAESError.randomBytesFailed }
+        
+        var iv = [UInt8](repeating: 0, count: ivLength)
+        let status2 = SecRandomCopyBytes(kSecRandomDefault, ivLength, &iv)
+        guard status2 == errSecSuccess else { throw InternxtAESError.randomBytesFailed }
+        
+      
+        let keyDerivator = KeyDerivation()
+        let derivedKeyBytes = keyDerivator.pbkdf2(
+            password: password,
+            salt: salt,
+            rounds: iterations,
+            derivedKeyLength: keyLength
+        )
+        let symmetricKey = SymmetricKey(data: derivedKeyBytes)
+        
+        // AES-256-GCM
+        let nonce = try AES.GCM.Nonce(data: iv)
+        let sealedBox = try AES.GCM.seal(plaintextData, using: symmetricKey, nonce: nonce)
+        
+        var finalData = Data()
+        finalData.append(contentsOf: salt)
+        finalData.append(contentsOf: iv)
+        finalData.append(sealedBox.tag)
+        finalData.append(sealedBox.ciphertext)
+        
+       
+        return finalData.base64EncodedString()
+    }
+    
+ 
+    public func decrypt(cipherBase64: String, password: String) throws -> String {
+        guard let data = Data(base64Encoded: cipherBase64) else {
+            throw InternxtAESError.invalidCipherBase64
+        }
+        
+        let minLength = saltLength + ivLength + tagLength
+        guard data.count > minLength else {
+            throw InternxtAESError.invalidPayloadLength
+        }
+        
+        let salt = [UInt8](data[0..<saltLength])
+        let iv = [UInt8](data[saltLength..<(saltLength + ivLength)])
+        let tag = data[(saltLength + ivLength)..<(saltLength + ivLength + tagLength)]
+        let ciphertext = data[(saltLength + ivLength + tagLength)...]
+        
+        // Derive key
+        let keyDerivator = KeyDerivation()
+        let derivedKeyBytes = keyDerivator.pbkdf2(
+            password: password,
+            salt: salt,
+            rounds: iterations,
+            derivedKeyLength: keyLength
+        )
+        let symmetricKey = SymmetricKey(data: derivedKeyBytes)
+        
+        // AES-256-GCM decryption
+        let nonce = try AES.GCM.Nonce(data: iv)
+        let sealedBox = try AES.GCM.SealedBox(nonce: nonce, ciphertext: ciphertext, tag: tag)
+        let decryptedData = try AES.GCM.open(sealedBox, using: symmetricKey)
+        
+        guard let plaintext = String(data: decryptedData, encoding: .utf8) else {
+            throw InternxtAESError.decryptionFailed
+        }
+        
+        return plaintext
+    }
+    
+
+    public func generateRandomUrlSafeString(length: Int) -> String {
+        if length <= 0 { return "" }
+        let numBytes = Int(ceil(Double(length * 3) / 4.0))
+        var bytes = [UInt8](repeating: 0, count: numBytes)
+        _ = SecRandomCopyBytes(kSecRandomDefault, numBytes, &bytes)
+        
+        let base64 = Data(bytes).base64EncodedString()
+        let urlSafe = base64
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        
+        return String(urlSafe.prefix(length))
+    }
+}

--- a/Sources/InternxtSwiftCore/Services/Crypto/InternxtAESCipher.swift
+++ b/Sources/InternxtSwiftCore/Services/Crypto/InternxtAESCipher.swift
@@ -107,11 +107,15 @@ public struct InternxtAESCipher {
     }
     
 
-    public func generateRandomUrlSafeString(length: Int) -> String {
+    public func generateRandomUrlSafeString(length: Int) throws -> String {
         if length <= 0 { return "" }
         let numBytes = Int(ceil(Double(length * 3) / 4.0))
         var bytes = [UInt8](repeating: 0, count: numBytes)
-        _ = SecRandomCopyBytes(kSecRandomDefault, numBytes, &bytes)
+        
+        let status = SecRandomCopyBytes(kSecRandomDefault, numBytes, &bytes)
+        guard status == errSecSuccess else {
+            throw InternxtAESError.randomBytesFailed
+        }
         
         let base64 = Data(bytes).base64EncodedString()
         let urlSafe = base64

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -598,4 +598,14 @@ public struct DriveAPI {
         
         return try await apiClient.fetch(type: ExistentFoldersResponse.self, endpoint, debugResponse: debug)
     }
+    
+    public func createSharing(payload: CreateSharingPayload, debug: Bool = false) async throws -> CreateSharingResponse {
+        let endpoint = Endpoint(
+            path: "\(self.baseUrl)/sharings/",
+            method: .POST,
+            body: payload.toJson()
+        )
+        
+        return try await apiClient.fetch(type: CreateSharingResponse.self, endpoint, debugResponse: debug)
+    }
 }

--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -608,4 +608,12 @@ public struct DriveAPI {
         
         return try await apiClient.fetch(type: CreateSharingResponse.self, endpoint, debugResponse: debug)
     }
+
+    public func getShareDomains(debug: Bool = false) async throws -> ShareDomainsResponse {
+        let endpoint = Endpoint(
+            path: "\(self.baseUrl)/storage/share/domains",
+            method: .GET
+        )
+        return try await apiClient.fetch(type: ShareDomainsResponse.self, endpoint, debugResponse: debug)
+    }
 }

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -807,10 +807,10 @@ public struct CreateSharingPayload: Encodable {
     public let encryptionKey: String
     public let encryptionAlgorithm: String
     public let encryptedCode: String
-    public let encryptedPassword: String
+    public let encryptedPassword: String?
     public let persistPreviousSharing: Bool
     
-    public init(itemId: String, itemType: String, encryptionKey: String, encryptionAlgorithm: String, encryptedCode: String, encryptedPassword: String, persistPreviousSharing: Bool) {
+    public init(itemId: String, itemType: String, encryptionKey: String, encryptionAlgorithm: String, encryptedCode: String, encryptedPassword: String?, persistPreviousSharing: Bool) {
         self.itemId = itemId
         self.itemType = itemType
         self.encryptionKey = encryptionKey
@@ -821,5 +821,23 @@ public struct CreateSharingPayload: Encodable {
     }
 }
 
-public struct CreateSharingResponse: Decodable {}
+public struct CreateSharingResponse: Decodable {
+    public let id: String
+    public let itemId: String
+    public let itemType: String
+    public let ownerId: String
+    public let sharedWith: String
+    public let sharedWithType: String
+    public let encryptionKey: String
+    public let encryptionAlgorithm: String
+    public let encryptedCode: String
+    public let encryptedPassword: String?
+    public let createdAt: String
+    public let updatedAt: String
+    public let type: String
+}
 
+
+public struct ShareDomainsResponse: Decodable {
+    public let list: [String]
+}

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -800,3 +800,26 @@ public struct GetNotificationsResponse: Codable {
     public let readAt: String
     public let isRead: Bool
 }
+
+public struct CreateSharingPayload: Encodable {
+    public let itemId: String
+    public let itemType: String
+    public let encryptionKey: String
+    public let encryptionAlgorithm: String
+    public let encryptedCode: String
+    public let encryptedPassword: String
+    public let persistPreviousSharing: Bool
+    
+    public init(itemId: String, itemType: String, encryptionKey: String, encryptionAlgorithm: String, encryptedCode: String, encryptedPassword: String, persistPreviousSharing: Bool) {
+        self.itemId = itemId
+        self.itemType = itemType
+        self.encryptionKey = encryptionKey
+        self.encryptionAlgorithm = encryptionAlgorithm
+        self.encryptedCode = encryptedCode
+        self.encryptedPassword = encryptedPassword
+        self.persistPreviousSharing = persistPreviousSharing
+    }
+}
+
+public struct CreateSharingResponse: Decodable {}
+

--- a/Tests/InternxtSwiftCoreTests/Services/Crypto/InternxtAESCipherTests.swift
+++ b/Tests/InternxtSwiftCoreTests/Services/Crypto/InternxtAESCipherTests.swift
@@ -61,6 +61,14 @@ final class InternxtAESCipherTests: XCTestCase {
             XCTAssertEqual(error as? InternxtAESError, InternxtAESError.invalidPayloadLength)
         }
     }
+    func testDecryptCiphertext() throws {
+        let plaintext = "test-mnemonic-pattern-secret"
+        let password = "test-password-123"
+        let encryptedBase64 = "Q8Yduw7dKJFZ98qcAgPk7VrZqEx+3a/L0kUDkPJslIY5m4X+xbjO5VwzPKEHu1asZSwfimNOR42/I+QEUyFaENnDAU4wiLaiQWyEQ72dSuLJ3l3ptSrhTnQui7L8zCG5Y4BD9C8LQw5G7iQLT+zenaeIMHfUktlJ46zGOw=="
+        
+        let decryptedText = try cipher.decrypt(cipherBase64: encryptedBase64, password: password)
+        XCTAssertEqual(decryptedText, plaintext)
+    }
     
     func testGenerateRandomUrlSafeString() throws {
         let length = 8

--- a/Tests/InternxtSwiftCoreTests/Services/Crypto/InternxtAESCipherTests.swift
+++ b/Tests/InternxtSwiftCoreTests/Services/Crypto/InternxtAESCipherTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import InternxtSwiftCore
+
+@available(macOS 10.15, *)
+final class InternxtAESCipherTests: XCTestCase {
+    
+    var cipher: InternxtAESCipher!
+    
+    override func setUp() {
+        super.setUp()
+        cipher = InternxtAESCipher()
+    }
+    
+    override func tearDown() {
+        cipher = nil
+        super.tearDown()
+    }
+    
+    func testEncryptDecryptSymmetry() throws {
+        let plaintext = "test-mnemonic-pattern-secret"
+        let password = "test-password-123"
+        
+        // 1. Encrypt
+        let encryptedBase64 = try cipher.encrypt(plaintext: plaintext, password: password)
+        XCTAssertFalse(encryptedBase64.isEmpty)
+        
+        // 2. Decrypt
+        let decryptedText = try cipher.decrypt(cipherBase64: encryptedBase64, password: password)
+        XCTAssertEqual(decryptedText, plaintext)
+    }
+    
+    func testDecryptWithWrongPasswordThrows() throws {
+        let plaintext = "secret-message"
+        let correctPassword = "correct-password"
+        let wrongPassword = "wrong-password"
+        
+        let encryptedBase64 = try cipher.encrypt(plaintext: plaintext, password: correctPassword)
+        
+        XCTAssertThrowsError(try cipher.decrypt(cipherBase64: encryptedBase64, password: wrongPassword)) { error in
+            XCTAssertNotNil(error)
+        }
+    }
+    
+    func testDecryptInvalidBase64Throws() {
+        let invalidBase64 = "this-is-not-base64!"
+        let password = "password"
+        
+        XCTAssertThrowsError(try cipher.decrypt(cipherBase64: invalidBase64, password: password)) { error in
+            XCTAssertEqual(error as? InternxtAESError, InternxtAESError.invalidCipherBase64)
+        }
+    }
+    
+    func testDecryptShortPayloadThrows() {
+        // Payload needs to be at least 64(salt) + 16(iv) + 16(tag) = 96 bytes.
+        // Let's create a 95-byte payload.
+        let shortData = Data(repeating: 0, count: 95)
+        let shortBase64 = shortData.base64EncodedString()
+        let password = "password"
+        
+        XCTAssertThrowsError(try cipher.decrypt(cipherBase64: shortBase64, password: password)) { error in
+            XCTAssertEqual(error as? InternxtAESError, InternxtAESError.invalidPayloadLength)
+        }
+    }
+    
+    func testGenerateRandomUrlSafeString() {
+        let length = 8
+        let randomString = cipher.generateRandomUrlSafeString(length: length)
+        
+        XCTAssertEqual(randomString.count, length)
+        // Ensure no standard base64 characters like '+' or '/' or '='
+        XCTAssertFalse(randomString.contains("+"))
+        XCTAssertFalse(randomString.contains("/"))
+        XCTAssertFalse(randomString.contains("="))
+    }
+}

--- a/Tests/InternxtSwiftCoreTests/Services/Crypto/InternxtAESCipherTests.swift
+++ b/Tests/InternxtSwiftCoreTests/Services/Crypto/InternxtAESCipherTests.swift
@@ -62,9 +62,9 @@ final class InternxtAESCipherTests: XCTestCase {
         }
     }
     
-    func testGenerateRandomUrlSafeString() {
+    func testGenerateRandomUrlSafeString() throws {
         let length = 8
-        let randomString = cipher.generateRandomUrlSafeString(length: length)
+        let randomString = try cipher.generateRandomUrlSafeString(length: length)
         
         XCTAssertEqual(randomString.count, length)
         // Ensure no standard base64 characters like '+' or '/' or '='


### PR DESCRIPTION
This PR introduces the necessary cryptographic tools, API endpoints, and models to support creating Public Share Links

 Changes
1. Cryptography (InternxtAESCipher.swift)

Added a new InternxtAESCipher class using Apple's CryptoKit.
Implements AES-256-GCM with PBKDF2-HMAC-SHA512 (2145 iterations) to exactly match the web client's encryption spec for public shares.
Added a URL-safe random string generator for share codes.
2. API & Models (DriveAPI.swift & DriveTypes.swift)

Models: Added CreateSharingPayload, CreateSharingResponse, and ShareDomainsResponse.
Endpoints: Added createSharing() (POST /sharings/) and getShareDomains() (GET gateway share domains).