### PR TITLE
feat: add getFileLimits endpoint to manage file size limits in the app

### DIFF
--- a/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
+++ b/Sources/InternxtSwiftCore/Services/HttpAPI/DriveAPI.swift
@@ -616,4 +616,12 @@ public struct DriveAPI {
         )
         return try await apiClient.fetch(type: ShareDomainsResponse.self, endpoint, debugResponse: debug)
     }
+    
+    public func getFileLimits(debug: Bool = false) async throws -> FileLimitsResponse {
+        let endpoint = Endpoint(
+            path: "\(self.baseUrl)/files/limits",
+            method: .GET
+        )
+        return try await apiClient.fetch(type: FileLimitsResponse.self, endpoint, debugResponse: debug)
+    }
 }

--- a/Sources/InternxtSwiftCore/Types/DriveTypes.swift
+++ b/Sources/InternxtSwiftCore/Types/DriveTypes.swift
@@ -841,3 +841,15 @@ public struct CreateSharingResponse: Decodable {
 public struct ShareDomainsResponse: Decodable {
     public let list: [String]
 }
+
+public struct FileLimitsResponse: Codable {
+    public let versioning: Versioning?
+    public let maxUploadFileSize: Int?
+}
+
+public struct Versioning: Codable {
+    public let enabled: Bool?
+    public let maxFileSize: Int?
+    public let retentionDays: Int?
+    public let maxVersions: Int?
+}


### PR DESCRIPTION
This PR adds the getFileLimits endpoint integration to retrieve and manage file size limits within the app.