### PR TITLE
fix: Resolve memory leak in file content hashing buffer

### DIFF
--- a/Sources/InternxtSwiftCore/Services/Network/Encrypt.swift
+++ b/Sources/InternxtSwiftCore/Services/Network/Encrypt.swift
@@ -61,6 +61,9 @@ public struct Encrypt {
 
         let bufferSize = 1024
         let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer {
+            buffer.deallocate()
+        }
 
         while stream.hasBytesAvailable {
             let read = stream.read(buffer, maxLength: bufferSize)


### PR DESCRIPTION
This PR resolves a persistent memory leak identified in the `Encrypt.getFileContentHash(stream:)` method within the `swift-core` package.